### PR TITLE
fix: ensure we decode the user's deck name

### DIFF
--- a/src/pages/Upload/components/UploadForm.tsx
+++ b/src/pages/Upload/components/UploadForm.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import getHeadersFilename from '../helpers/getHeadersFilename';
 import isAboveFreeTier from '../helpers/isAboveFreeTier';
 import DownloadButton from './DownloadButton';
 import DropParagraph from './DropParagraph';
@@ -84,7 +85,7 @@ function UploadForm({ setErrorMessage, isPatron }: UploadFormProps) {
         setDownloadLink(null);
         return setErrorMessage(text);
       }
-      const fileNameHeader = request.headers.get('File-Name'.toLowerCase());
+      const fileNameHeader = getHeadersFilename(request.headers);
       if (fileNameHeader) {
         setDeckName(fileNameHeader);
       } else {

--- a/src/pages/Upload/helpers/getHeadersFilename.test.ts
+++ b/src/pages/Upload/helpers/getHeadersFilename.test.ts
@@ -1,0 +1,7 @@
+import getHeadersFilename from './getHeadersFilename';
+
+const mockedHeaders = new Headers();
+mockedHeaders.get = () => 'My%20uber%20cool%20deck.apkg';
+test('getHeadersFilename', () => {
+  expect(getHeadersFilename(mockedHeaders)).toBe('My uber cool deck.apkg');
+});

--- a/src/pages/Upload/helpers/getHeadersFilename.ts
+++ b/src/pages/Upload/helpers/getHeadersFilename.ts
@@ -1,0 +1,6 @@
+const getHeadersFilename = (headers: Response['headers']) => {
+  const filename = headers.get('File-Name');
+  return decodeURIComponent(filename);
+};
+
+export default getHeadersFilename;


### PR DESCRIPTION
It can contain characters that are invalid values in HTTP headers.