### PR TITLE
package: resolve packages due to webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,16 @@
   "name": "web",
   "version": "0.1.1",
   "private": true,
+  "resolve": {
+    "fallback": {
+      "assert": false,
+      "http": false,
+      "https": false,
+      "stream": false,
+      "url": false,
+      "zlib": false
+    }
+  },
   "dependencies": {
     "@fremtind/jkl-accordion": "^7.0.3",
     "@fremtind/jkl-accordion-react": "^7.0.10",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -91,12 +91,10 @@ function Footer() {
             </a>
           </p>
           <p>
-            <a href="https://www.digitalocean.com/?refcode=c5a16996cd0e&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=CopyPaste">
+            <a href="https://www.digitalocean.com/?refcode=c5a16996cd0e&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge">
               <img
-                style={{ width: '201px' }}
-                src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/PoweredByDO/DO_Powered_by_Badge_blue.svg"
-                alt="Powered by DigitalOcean"
-                loading="lazy"
+                src="https://web-platforms.sfo2.cdn.digitaloceanspaces.com/WWW/Badge%201.svg"
+                alt="DigitalOcean Referral Badge"
               />
             </a>
           </p>


### PR DESCRIPTION
Fixes the following kind of warnings:
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "http": require.resolve("stream-http") }'
	- install 'stream-http'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "http": false }