### PR TITLE
fix: file-input uses content outside component

### DIFF
--- a/src/pages/Upload/components/UploadForm.tsx
+++ b/src/pages/Upload/components/UploadForm.tsx
@@ -128,7 +128,9 @@ function UploadForm({ setErrorMessage, isPatron }: UploadFormProps) {
         handleSubmit(event);
       }}
     >
-      <div>
+      <div
+        class="container"
+      >
         <div>
           <div className="field">
             <DropParagraph hover={dropHover}>

--- a/src/pages/Upload/components/UploadForm.tsx
+++ b/src/pages/Upload/components/UploadForm.tsx
@@ -129,7 +129,7 @@ function UploadForm({ setErrorMessage, isPatron }: UploadFormProps) {
       }}
     >
       <div
-        class="container"
+        className="container"
       >
         <div>
           <div className="field">


### PR DESCRIPTION
`.file-input` is trying to cover all container (width 100%, height: 100%), but there is no relative element in this component, is is starting to use UploadForm as a container. Then it is not possible to use UploadForm element
![image](https://user-images.githubusercontent.com/39843372/192785297-e9fdae5c-5c30-4bed-ba7b-8e2f0d413c27.png)
