### PR TITLE
feat: add selection control for creating extracts on mobile

### DIFF
--- a/src/pages/Learn/components/BlockControls/BlockControls.tsx
+++ b/src/pages/Learn/components/BlockControls/BlockControls.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useSpeechSynthesis } from '../../helpers/useSpeechSynthesis';
 import { ControlButton } from '../ControlButton';
 import { DeleteIcon } from './icons/DeleteIcon';
-import { ScissorsIcon } from './icons/ScissorsIcon';
 import { SearchIcon } from './icons/SearchIcon';
 import { SpeakerWaveIcon } from './icons/SpeakerWaveIcon';
 
@@ -12,20 +11,16 @@ interface BlockControlsProps {
   index: number;
   setIndex: React.Dispatch<React.SetStateAction<number>>;
   onDelete: () => void;
-  onExtract: () => void;
   onCreateNote: () => void;
 }
 
 export function BlockControls(props: BlockControlsProps) {
-  const { loading, total, index, setIndex, onDelete, onExtract, onCreateNote } =
-    props;
-  const [metaPressed, setMeta] = useState(false);
+  const { loading, total, index, setIndex, onDelete, onCreateNote } = props;
   const speak = useSpeechSynthesis();
   const goToNextBlock = () => setIndex(Math.min(index + 1, total - 1));
   const gotToPreviousBlock = () => setIndex(Math.max(index - 1, 0));
 
   const [loadCreatingNote, setLoadCreatingNote] = useState(false);
-  const [loadExtract, setLoadExtract] = useState(false);
   const [loadDeleteBlock, setLoadDelete] = useState(false);
   const [loadNextBlock, setLoadNextBlock] = useState(false);
   const [loadPreviousBlock, setLoadPreviousBlock] = useState(false);
@@ -34,9 +29,6 @@ export function BlockControls(props: BlockControlsProps) {
     if (!loading) {
       if (loadCreatingNote) {
         setLoadCreatingNote(false);
-      }
-      if (loadExtract) {
-        setLoadExtract(false);
       }
       if (loadDeleteBlock) {
         setLoadDelete(false);
@@ -59,24 +51,11 @@ export function BlockControls(props: BlockControlsProps) {
         goToNextBlock();
       } else if (key === 'Backspace' || key === 'Delete') {
         onDelete();
-      } else if (key === 'Meta' || key === 'Alt') {
-        setMeta(true);
-      } else if (key === 'x' && metaPressed) {
-        onExtract();
-        setMeta(false);
-      }
-    };
-    const handleKeyUp = (event: KeyboardEvent) => {
-      const { key } = event;
-      if (key === 'Meta') {
-        setMeta(false);
       }
     };
     window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('keyup', handleKeyUp);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('keyup', handleKeyUp);
     };
   });
 
@@ -128,17 +107,6 @@ export function BlockControls(props: BlockControlsProps) {
         label="Read text"
         onClick={() => speak()}
         icon={<SpeakerWaveIcon />}
-      />
-      <ControlButton
-        loading={loadExtract}
-        label="extract"
-        onClick={() => {
-          if (!loading) {
-            setLoadExtract(true);
-            onExtract();
-          }
-        }}
-        icon={<ScissorsIcon />}
       />
       <ControlButton
         loading={loadCreatingNote}

--- a/src/pages/Learn/components/SelectionButton.tsx
+++ b/src/pages/Learn/components/SelectionButton.tsx
@@ -1,35 +1,32 @@
 import { ReactNode } from 'react';
-import styled from 'styled-components';
 
-interface ControlButtonProps {
-  label: string;
+interface SelectionButtonProps {
+  label: ReactNode;
   onClick: () => void;
   icon: ReactNode;
   loading: boolean;
+  disabled: boolean;
 }
 
-const Paragraph = styled.p`
-  * {
-    user-select: none;
-  }
-`;
-
-export function ControlButton({
+export function SelectionButton({
   loading,
   label,
   onClick,
-  icon
-}: ControlButtonProps) {
+  icon,
+  disabled
+}: SelectionButtonProps) {
   return (
-    <Paragraph className="control">
+    <p className="control">
       <button
-        aria-label={label}
+        disabled={disabled}
+        // aria-label={label}
         className={`button is-small ${loading ? 'is-loading' : ''}`}
         type="button"
         onClick={onClick}
       >
         <span className="icon is-small">{icon}</span>
+        {label}
       </button>
-    </Paragraph>
+    </p>
   );
 }

--- a/src/pages/Learn/helpers/useRenderBlock.tsx
+++ b/src/pages/Learn/helpers/useRenderBlock.tsx
@@ -12,7 +12,10 @@ type RenderBlockResponse = {
   backSide: string;
 };
 
-export const useRenderBlock = (id: string | undefined): BackSide => {
+export const useRenderBlock = (
+  id: string | undefined,
+  refetch: boolean
+): BackSide => {
   const [backSide, setBackSide] = useState('loading');
   const [frontSide, setFrontSide] = useState('loading');
   const [loading, setLoading] = useState(false);
@@ -30,6 +33,6 @@ export const useRenderBlock = (id: string | undefined): BackSide => {
         }
       });
     }
-  }, [id]);
+  }, [id, refetch]);
   return { loading, backSide, frontSide };
 };

--- a/src/pages/Learn/helpers/useSelection.tsx
+++ b/src/pages/Learn/helpers/useSelection.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+export const useSelection = (selectionHandler: (selection: string) => void) => {
+  useEffect(() => {
+    const selectionChange = () => {
+      const text = document.getSelection()?.toString();
+      selectionHandler(text?.trim() ?? '');
+    };
+    document.addEventListener('selectionchange', selectionChange);
+    return () =>
+      document.removeEventListener('selectionchange', selectionChange);
+  }, [selectionHandler]);
+};


### PR DESCRIPTION
Turns out text selection is easier on desktop than mobile. So we need separate component to handle this well. Also improved the loading of extracts.