### PR TITLE
chore: bring back google ads

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -91,6 +91,8 @@
 </head>
 
 <body>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9593032741719801"
+     crossorigin="anonymous"></script>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <!--


### PR DESCRIPTION
will be used to fund development