### PR TITLE
perf: Add default search query to improve initial load time

### DIFF
--- a/src/components/NavigationBar/helpers/getSearchPath.ts
+++ b/src/components/NavigationBar/helpers/getSearchPath.ts
@@ -1,0 +1,1 @@
+export const getSearchPath = (query: string) => `/search?q=${query}`;

--- a/src/components/NavigationBar/helpers/useNavbarEnd.tsx
+++ b/src/components/NavigationBar/helpers/useNavbarEnd.tsx
@@ -4,6 +4,7 @@ import { getVisibleText } from '../../../lib/text/getVisibleText';
 import Backend from '../../../lib/backend';
 import NavbarItem from '../NavbarItem';
 import { getUserLocals } from '../../../lib/backend/getUserLocals';
+import { getSearchPath } from './getSearchPath';
 
 export default function useNavbarEnd(path: string, backend: Backend) {
   const onLogOut = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
@@ -25,9 +26,11 @@ export default function useNavbarEnd(path: string, backend: Backend) {
       <NavbarItem href="/contact" path={path}>
         {getVisibleText('navigation.contact')}
       </NavbarItem>
-      {!isLoading && !isPaying && <NavbarItem href="/pricing" path={path}>
-        {getVisibleText('navigation.pricing')}
-      </NavbarItem>}
+      {!isLoading && !isPaying && (
+        <NavbarItem href="/pricing" path={path}>
+          {getVisibleText('navigation.pricing')}
+        </NavbarItem>
+      )}
       <NavbarItem href="/upload" path={path}>
         {getVisibleText('navigation.upload')}
       </NavbarItem>
@@ -37,7 +40,7 @@ export default function useNavbarEnd(path: string, backend: Backend) {
       <NavbarItem href="/favorites" path={path}>
         {getVisibleText('navigation.favorites')}
       </NavbarItem>
-      <NavbarItem href="/search" path={path}>
+      <NavbarItem href={getSearchPath('anki')} path={path}>
         {getVisibleText('navigation.search')}
       </NavbarItem>
       <NavbarItem path={path} href="/settings">

--- a/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.ts
+++ b/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.ts
@@ -2,14 +2,15 @@ import React, {
   FormEventHandler,
   SetStateAction,
   SyntheticEvent,
-  useState
+  useState,
 } from 'react';
 import { useCookies } from 'react-cookie';
 import {
   ErrorHandlerType,
-  getErrorMessage
+  getErrorMessage,
 } from '../../../../../components/errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../../../../lib/backend/get2ankiApi';
+import { getSearchPath } from '../../../../../components/NavigationBar/helpers/getSearchPath';
 
 interface LoginState {
   email: string;
@@ -35,7 +36,7 @@ export const useHandleLoginSubmit = (onError: ErrorHandlerType): LoginState => {
       if (res.status === 200) {
         const { token, redirect } = await res.json();
         setCookie('token', token);
-        window.location.href = redirect ?? '/search';
+        window.location.href = redirect ?? getSearchPath('anki');
       } else {
         onError(
           new Error(
@@ -57,6 +58,6 @@ export const useHandleLoginSubmit = (onError: ErrorHandlerType): LoginState => {
     loading,
     onSubmit,
     setEmail,
-    setPassword
+    setPassword,
   };
 };


### PR DESCRIPTION
Empty search queries take 6 seconds longer to load compared to queries
with content. Added 'anki' as default search term to improve user
experience.

The sample test I used was small but still noticeable.
