### PR TITLE
Update file deletion time from 21 minutes to 2 hours

### DIFF
--- a/src/pages/UploadPage/UploadPage.tsx
+++ b/src/pages/UploadPage/UploadPage.tsx
@@ -58,8 +58,7 @@ export function UploadPage({ setErrorMessage }: Props) {
             <p>The following files are supported: {readableSupportedFiles}</p>
 
             <InfoMessage>
-              All files uploaded here are automatically deleted after 21
-              minutes.
+              All files uploaded here are automatically deleted after 2 hours.
             </InfoMessage>
             <SettingsModal
               setError={setErrorMessage}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the file retention period information displayed on the upload page to reflect that uploaded files are retained for 2 hours instead of 21 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->