### PR TITLE
fix: hide empty state while search is in progress

### DIFF
--- a/src/pages/SearchPage/components/SearchPresenter.tsx
+++ b/src/pages/SearchPage/components/SearchPresenter.tsx
@@ -40,6 +40,7 @@ export default function SearchPresenter(props: SearchPresenterProps) {
         setError={setError}
         setFavorites={setFavorites}
         results={myPages}
+        handleEmpty={!inProgress}
       />
     </>
   );


### PR DESCRIPTION
When the search query changed, results were immediately cleared before the debounced request fired, causing the empty state to flash during every search. Pass handleEmpty={!inProgress} so the empty state only renders after the search completes with no results.