### PR TITLE
chore(a11y): address SonarCloud findings on StepIndicator

### DIFF
--- a/src/components/StepIndicator/StepIndicator.module.css
+++ b/src/components/StepIndicator/StepIndicator.module.css
@@ -3,6 +3,9 @@
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .pill {
@@ -45,13 +48,13 @@
 }
 
 .pillPending {
-  color: #9ca3af;
+  color: #4b5563;
   background-color: #f9fafb;
   border-color: #e5e7eb;
 }
 
 .pillPending .dot {
-  background-color: #d1d5db;
+  background-color: #9ca3af;
 }
 
 .substep {

--- a/src/components/StepIndicator/StepIndicator.tsx
+++ b/src/components/StepIndicator/StepIndicator.tsx
@@ -8,34 +8,32 @@ interface Props {
 
 const STEP_LABELS = ['Uploaded', 'Parsing', 'Generating', 'Packaging'] as const;
 
+function getPillClass(step: StepIndex, currentStep: StepIndex): string {
+  if (step < currentStep) return styles.pillDone;
+  if (step === currentStep) return styles.pillActive;
+  return styles.pillPending;
+}
+
 export function StepIndicator({ currentStep, substep }: Props) {
   return (
-    <div
-      className={styles.indicator}
-      role="progressbar"
-      aria-valuemin={1}
-      aria-valuemax={STEP_LABELS.length}
-      aria-valuenow={currentStep}
-      aria-valuetext={`Step ${currentStep} of ${STEP_LABELS.length}: ${STEP_LABELS[currentStep - 1]}${substep ? ` (${substep})` : ''}`}
-    >
+    <ol className={styles.indicator} aria-label="Conversion progress">
       {STEP_LABELS.map((label, index) => {
         const step = (index + 1) as StepIndex;
-        let pillClass = styles.pillPending;
-        if (step < currentStep) {
-          pillClass = styles.pillDone;
-        } else if (step === currentStep) {
-          pillClass = styles.pillActive;
-        }
+        const isActive = step === currentStep;
         return (
-          <span key={label} className={`${styles.pill} ${pillClass}`}>
+          <li
+            key={label}
+            className={`${styles.pill} ${getPillClass(step, currentStep)}`}
+            aria-current={isActive ? 'step' : undefined}
+          >
             <span className={styles.dot} />
             {label}
-            {step === currentStep && substep && (
+            {isActive && substep && (
               <span className={styles.substep}>({substep})</span>
             )}
-          </span>
+          </li>
         );
       })}
-    </div>
+    </ol>
   );
 }


### PR DESCRIPTION
## Summary
- Fix pending-pill text/dot contrast so it clears WCAG AA against the surrounding background.
- Replace \`role=\"progressbar\"\` + numeric ARIA attributes with a semantic \`<ol>\` + \`aria-current=\"step\"\`. A multi-step indicator is not a progress bar, and this also eliminates the nested template literal flagged by SonarCloud.

Addresses all 3 SonarCloud issues raised on the merged StepIndicator PR.

## Test plan
- [ ] \`pnpm test\` passes locally (verified)
- [ ] \`pnpm exec tsc --noEmit\` clean (verified)
- [ ] Visual check of Downloads page step indicator in browser
- [ ] Screen-reader walk-through to confirm step announcements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color scheme for pending step indicators to enhance visual clarity.

* **Accessibility**
  * Improved semantic structure and accessibility of the step indicator component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->