### PR TITLE
feat: surface share-files-for-debugging opt-in

### DIFF
--- a/src/pages/DebugPage/DebugPage.module.css
+++ b/src/pages/DebugPage/DebugPage.module.css
@@ -97,10 +97,22 @@
 .dataCardCount {
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
-  color: #6b7280;
-  background: #eef2ff;
+  color: #1e3a8a;
+  background: #dbeafe;
   padding: 2px 8px;
   border-radius: 9999px;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .dataTable {

--- a/src/pages/DebugPage/DebugPage.module.css
+++ b/src/pages/DebugPage/DebugPage.module.css
@@ -1,0 +1,75 @@
+.shareCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  margin: 0 0 2rem;
+  border-radius: 12px;
+  border: 1px solid #bfdbfe;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+  box-shadow: 0 1px 2px rgba(30, 64, 175, 0.08);
+}
+
+.shareHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: #1e3a8a;
+}
+
+.shareBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  background: #1d4ed8;
+  color: white;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  letter-spacing: 0.02em;
+}
+
+.shareDescription {
+  margin: 0;
+  color: #1e3a8a;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.shareControls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
+}
+
+.shareToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: #1e3a8a;
+  cursor: pointer;
+}
+
+.shareStatus {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  padding: 4px 10px;
+  border-radius: 9999px;
+}
+
+.shareStatusOn {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.shareStatusOff {
+  background: #fee2e2;
+  color: #991b1b;
+}

--- a/src/pages/DebugPage/DebugPage.module.css
+++ b/src/pages/DebugPage/DebugPage.module.css
@@ -73,3 +73,78 @@
   background: #fee2e2;
   color: #991b1b;
 }
+
+.dataCard {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: white;
+  overflow: hidden;
+  margin-bottom: 2rem;
+}
+
+.dataCardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #f3f4f6;
+  background: #f9fafb;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: #374151;
+}
+
+.dataCardCount {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: #6b7280;
+  background: #eef2ff;
+  padding: 2px 8px;
+  border-radius: 9999px;
+}
+
+.dataTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.dataTable tr:not(:last-child) td {
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.dataTable td {
+  padding: 0.5rem 1rem;
+  vertical-align: top;
+}
+
+.dataKey {
+  width: 30%;
+  color: #6b7280;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
+.dataValue {
+  color: #111827;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: var(--text-xs);
+  word-break: break-word;
+}
+
+.dataRowHighlight {
+  background: #eff6ff;
+}
+
+.dataRowHighlight .dataKey,
+.dataRowHighlight .dataValue {
+  color: #1e3a8a;
+}
+
+.dataEmpty {
+  padding: 1rem;
+  color: #6b7280;
+  font-size: var(--text-sm);
+  text-align: center;
+}

--- a/src/pages/DebugPage/DebugPage.tsx
+++ b/src/pages/DebugPage/DebugPage.tsx
@@ -26,7 +26,7 @@ export function DebugPage() {
   };
 
   return (
-    <div className={styles.pageNarrow}>
+    <div className={styles.page}>
       <h1 className={styles.title}>Debug page</h1>
 
       <section className={debugStyles.shareCard}>

--- a/src/pages/DebugPage/DebugPage.tsx
+++ b/src/pages/DebugPage/DebugPage.tsx
@@ -3,9 +3,15 @@ import { getKeys } from './helpers/getKeys';
 import { ErrorPresenter } from '../../components/errors/ErrorPresenter';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import styles from '../../styles/shared.module.css';
+import debugStyles from './DebugPage.module.css';
+
+const SHARE_FILES_KEY = 'share-files-for-debugging';
 
 export function DebugPage() {
   const [show, setShow] = useState(false);
+  const [shareFiles, setShareFiles] = useState(
+    localStorage.getItem(SHARE_FILES_KEY) === 'true'
+  );
   const { data } = useUserLocals();
 
   const resetLocalStorage = () => {
@@ -13,9 +19,49 @@ export function DebugPage() {
     window.location.reload();
   };
 
+  const toggleShareFiles = () => {
+    const next = !shareFiles;
+    setShareFiles(next);
+    localStorage.setItem(SHARE_FILES_KEY, String(next));
+  };
+
   return (
     <div className={styles.pageNarrow}>
       <h1 className={styles.title}>Debug page</h1>
+
+      <section className={debugStyles.shareCard}>
+        <div className={debugStyles.shareHeader}>
+          <span className={debugStyles.shareBadge}>Opt-in</span>
+          Help us fix bugs faster
+        </div>
+        <p className={debugStyles.shareDescription}>
+          When a conversion fails, enabling this sends the uploaded files and
+          error details to the 2anki team so we can reproduce and fix the
+          issue. It is <strong>off by default</strong> to keep your notes
+          private. Turn it on before filing a bug report so your next failed
+          upload reaches us.
+        </p>
+        <div className={debugStyles.shareControls}>
+          <label className={debugStyles.shareToggle}>
+            <input
+              type="checkbox"
+              checked={shareFiles}
+              onChange={toggleShareFiles}
+            />
+            Share files when a conversion fails
+          </label>
+          <span
+            className={`${debugStyles.shareStatus} ${
+              shareFiles
+                ? debugStyles.shareStatusOn
+                : debugStyles.shareStatusOff
+            }`}
+          >
+            {shareFiles ? 'On — files will be sent on failure' : 'Off — nothing is sent'}
+          </span>
+        </div>
+      </section>
+
       <h2 className={styles.subtitle}>User Locals</h2>
       <pre>{JSON.stringify(data, null, 2)}</pre>
 

--- a/src/pages/DebugPage/DebugPage.tsx
+++ b/src/pages/DebugPage/DebugPage.tsx
@@ -7,6 +7,72 @@ import debugStyles from './DebugPage.module.css';
 
 const SHARE_FILES_KEY = 'share-files-for-debugging';
 
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return String(value);
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+function UserLocalsCard({ data }: { data: unknown }) {
+  const entries =
+    data && typeof data === 'object' ? Object.entries(data as object) : [];
+  return (
+    <section className={debugStyles.dataCard}>
+      <header className={debugStyles.dataCardHeader}>
+        User Locals
+        <span className={debugStyles.dataCardCount}>{entries.length}</span>
+      </header>
+      {entries.length === 0 ? (
+        <div className={debugStyles.dataEmpty}>No data</div>
+      ) : (
+        <table className={debugStyles.dataTable}>
+          <tbody>
+            {entries.map(([key, value]) => (
+              <tr key={key}>
+                <td className={debugStyles.dataKey}>{key}</td>
+                <td className={debugStyles.dataValue}>{formatValue(value)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
+function LocalStorageCard({ highlightKey }: { highlightKey: string }) {
+  const keys = getKeys(localStorage);
+  return (
+    <section className={debugStyles.dataCard}>
+      <header className={debugStyles.dataCardHeader}>
+        Local Storage
+        <span className={debugStyles.dataCardCount}>{keys.length}</span>
+      </header>
+      {keys.length === 0 ? (
+        <div className={debugStyles.dataEmpty}>Empty</div>
+      ) : (
+        <table className={debugStyles.dataTable}>
+          <tbody>
+            {keys.map((key) => (
+              <tr
+                key={key}
+                className={
+                  key === highlightKey ? debugStyles.dataRowHighlight : undefined
+                }
+              >
+                <td className={debugStyles.dataKey}>{key}</td>
+                <td className={debugStyles.dataValue}>
+                  {localStorage.getItem(key) ?? ''}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
 export function DebugPage() {
   const [show, setShow] = useState(false);
   const [shareFiles, setShareFiles] = useState(
@@ -62,20 +128,8 @@ export function DebugPage() {
         </div>
       </section>
 
-      <h2 className={styles.subtitle}>User Locals</h2>
-      <pre>{JSON.stringify(data, null, 2)}</pre>
-
-      <h2 className={`${styles.subtitle} ${styles.sectionHeading}`}>
-        Local Storage
-      </h2>
-      <pre>
-        {getKeys(localStorage).map(
-          (key) =>
-            `localStorage.setItem(${key}, ${JSON.stringify(
-              localStorage.getItem(key)
-            )});\n`
-        )}
-      </pre>
+      <UserLocalsCard data={data} />
+      <LocalStorageCard highlightKey={SHARE_FILES_KEY} />
       <div className={styles.debugActions}>
         <button
           className={styles.btnOutline}

--- a/src/pages/DebugPage/DebugPage.tsx
+++ b/src/pages/DebugPage/DebugPage.tsx
@@ -13,26 +13,44 @@ function formatValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
+interface UserLocalsShape {
+  user?: { id?: number };
+  locals?: {
+    patreon?: boolean;
+    subscriber?: boolean;
+    subscriptionInfo?: { active?: boolean };
+  };
+}
+
+function getPlanLabel(locals: UserLocalsShape['locals']): string {
+  if (locals?.patreon) return 'Lifetime (Patreon)';
+  if (locals?.subscriber || locals?.subscriptionInfo?.active) {
+    return 'Active subscriber';
+  }
+  return 'Free';
+}
+
 function UserLocalsCard({ data }: { data: unknown }) {
-  const entries =
-    data && typeof data === 'object' ? Object.entries(data as object) : [];
+  const shape =
+    data && typeof data === 'object' ? (data as UserLocalsShape) : null;
+  const userId = shape?.user?.id ?? null;
+  const plan = shape ? getPlanLabel(shape.locals) : null;
   return (
     <section className={debugStyles.dataCard}>
-      <header className={debugStyles.dataCardHeader}>
-        User Locals
-        <span className={debugStyles.dataCardCount}>{entries.length}</span>
-      </header>
-      {entries.length === 0 ? (
-        <div className={debugStyles.dataEmpty}>No data</div>
+      <header className={debugStyles.dataCardHeader}>User Locals</header>
+      {userId == null ? (
+        <div className={debugStyles.dataEmpty}>Not signed in</div>
       ) : (
         <table className={debugStyles.dataTable}>
           <tbody>
-            {entries.map(([key, value]) => (
-              <tr key={key}>
-                <td className={debugStyles.dataKey}>{key}</td>
-                <td className={debugStyles.dataValue}>{formatValue(value)}</td>
-              </tr>
-            ))}
+            <tr>
+              <td className={debugStyles.dataKey}>user id</td>
+              <td className={debugStyles.dataValue}>{userId}</td>
+            </tr>
+            <tr>
+              <td className={debugStyles.dataKey}>plan</td>
+              <td className={debugStyles.dataValue}>{plan}</td>
+            </tr>
           </tbody>
         </table>
       )}

--- a/src/pages/DebugPage/DebugPage.tsx
+++ b/src/pages/DebugPage/DebugPage.tsx
@@ -7,12 +7,6 @@ import debugStyles from './DebugPage.module.css';
 
 const SHARE_FILES_KEY = 'share-files-for-debugging';
 
-function formatValue(value: unknown): string {
-  if (value === null || value === undefined) return String(value);
-  if (typeof value === 'string') return value;
-  return JSON.stringify(value);
-}
-
 interface UserLocalsShape {
   user?: { id?: number };
   locals?: {
@@ -30,7 +24,18 @@ function getPlanLabel(locals: UserLocalsShape['locals']): string {
   return 'Free';
 }
 
-function UserLocalsCard({ data }: { data: unknown }) {
+function KeyValueTableHead() {
+  return (
+    <thead className={debugStyles.visuallyHidden}>
+      <tr>
+        <th scope="col">Key</th>
+        <th scope="col">Value</th>
+      </tr>
+    </thead>
+  );
+}
+
+function UserLocalsCard({ data }: Readonly<{ data: unknown }>) {
   const shape =
     data && typeof data === 'object' ? (data as UserLocalsShape) : null;
   const userId = shape?.user?.id ?? null;
@@ -42,6 +47,7 @@ function UserLocalsCard({ data }: { data: unknown }) {
         <div className={debugStyles.dataEmpty}>Not signed in</div>
       ) : (
         <table className={debugStyles.dataTable}>
+          <KeyValueTableHead />
           <tbody>
             <tr>
               <td className={debugStyles.dataKey}>user id</td>
@@ -58,18 +64,21 @@ function UserLocalsCard({ data }: { data: unknown }) {
   );
 }
 
-function LocalStorageCard({ highlightKey }: { highlightKey: string }) {
+function LocalStorageCard({
+  highlightKey,
+}: Readonly<{ highlightKey: string }>) {
   const keys = getKeys(localStorage);
   return (
     <section className={debugStyles.dataCard}>
       <header className={debugStyles.dataCardHeader}>
-        Local Storage
+        <span>Local Storage</span>
         <span className={debugStyles.dataCardCount}>{keys.length}</span>
       </header>
       {keys.length === 0 ? (
         <div className={debugStyles.dataEmpty}>Empty</div>
       ) : (
         <table className={debugStyles.dataTable}>
+          <KeyValueTableHead />
           <tbody>
             {keys.map((key) => (
               <tr
@@ -116,7 +125,7 @@ export function DebugPage() {
       <section className={debugStyles.shareCard}>
         <div className={debugStyles.shareHeader}>
           <span className={debugStyles.shareBadge}>Opt-in</span>
-          Help us fix bugs faster
+          <span>Help us fix bugs faster</span>
         </div>
         <p className={debugStyles.shareDescription}>
           When a conversion fails, enabling this sends the uploaded files and
@@ -132,7 +141,7 @@ export function DebugPage() {
               checked={shareFiles}
               onChange={toggleShareFiles}
             />
-            Share files when a conversion fails
+            <span>Share files when a conversion fails</span>
           </label>
           <span
             className={`${debugStyles.shareStatus} ${
@@ -141,7 +150,9 @@ export function DebugPage() {
                 : debugStyles.shareStatusOff
             }`}
           >
-            {shareFiles ? 'On — files will be sent on failure' : 'Off — nothing is sent'}
+            {shareFiles
+              ? 'On — files will be sent on failure'
+              : 'Off — nothing is sent'}
           </span>
         </div>
       </section>

--- a/src/pages/DocsPage/content/misc/privacy-policy.md
+++ b/src/pages/DocsPage/content/misc/privacy-policy.md
@@ -7,7 +7,9 @@ If you have any questions about our privacy practices, please don't hesitate to 
 
 ## Data Processing
 
-Some file handling occurs on external servers to reduce browser overhead. For debugging purposes, your cards may be logged but are not preserved over time. If you accidentally upload sensitive information, contact us and we'll delete the server logs.
+Some file handling occurs on external servers to reduce browser overhead. Failed conversions are logged in the server error log (no file contents), but your uploaded files are **not** stored or emailed anywhere unless you opt in via the **Share files when a conversion fails** setting on the [/debug](/debug) page. When that opt-in is on, the uploaded files and error details are sent to the 2anki team so we can reproduce the issue.
+
+If you accidentally upload sensitive information, contact us and we'll delete the server logs.
 
 We log IP addresses for research purposes. No other personally identifiable information is collected or harvested.
 

--- a/src/pages/DocsPage/content/troubleshooting/bug-report.md
+++ b/src/pages/DocsPage/content/troubleshooting/bug-report.md
@@ -5,6 +5,10 @@ description: Template for reporting bugs
 
 Help us improve 2anki.net by filing a bug report. You can submit it publicly on [GitHub](https://github.com/2anki/2anki.net/issues/new?assignees=&labels=&template=bug_report.md&title=) or privately by emailing [support@2anki.net](mailto:support@2anki.net).
 
+## Before you report
+
+If the bug is a failed conversion, visit the [/debug](/debug) page and enable **Share files when a conversion fails**. This is off by default to keep your notes private, but with it enabled the next failed upload will send the file and error details straight to our inbox — no back-and-forth needed. Turn it back off once the issue is fixed.
+
 Use the template below.
 
 ## Describe the bug


### PR DESCRIPTION
## Summary
- Add a prominent opt-in card at the top of `/debug` so users who hit repeated failures can enable \`share-files-for-debugging\` without friction. Clear on/off status indicator makes the current state obvious.
- Bug-report docs now tell users to flip the toggle on before filing a bug, so the next failed upload reaches the team without back-and-forth.
- Privacy policy updated to reflect that uploads are not stored or emailed unless this opt-in is on.

Pairs with the server-side gate in 2anki/server#1971.

## Test plan
- [ ] \`pnpm test\` passes (verified)
- [ ] \`pnpm exec tsc --noEmit\` clean (verified)
- [ ] Visit \`/debug\`, toggle on/off, verify \`localStorage.share-files-for-debugging\` reflects the state
- [ ] Trigger a failed upload with the toggle on and confirm the server receives the debug email
- [ ] Trigger a failed upload with the toggle off and confirm no email is sent
- [ ] Read docs pages at /documentation/troubleshooting/bug-report and /documentation/misc/privacy-policy to confirm updated copy renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)