### PR TITLE
fix(navbar): surface /upload link for anonymous users

### DIFF
--- a/src/components/NavigationBar/components/RightSide.tsx
+++ b/src/components/NavigationBar/components/RightSide.tsx
@@ -9,6 +9,9 @@ interface RightSideProps {
 export function RightSide({ path }: Readonly<RightSideProps>) {
   return (
     <div className={styles.navEnd}>
+      <NavbarItem href="/upload" path={path}>
+        {getVisibleText('navigation.upload')}
+      </NavbarItem>
       <NavbarItem href="/documentation" path={path}>
         {getVisibleText('navigation.documentation')}
       </NavbarItem>


### PR DESCRIPTION
RightSide lost the Upload entry during the CSS-modules refactor, leaving anon visitors with no nav path to the public upload page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an upload option to the navigation bar, making upload functionality more accessible from the main interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->