### PR TITLE
fix(footer): point Terms and Privacy links at in-app docs

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,22 +12,10 @@ function Footer() {
               <a href="/about">About</a>
             </li>
             <li>
-              <a
-                target="_blank"
-                href="https://docs.2anki.net/misc/terms-of-service/"
-                rel="noreferrer"
-              >
-                Terms
-              </a>
+              <a href="/documentation/misc/terms-of-service">Terms</a>
             </li>
             <li>
-              <a
-                target="_blank"
-                href="https://docs.2anki.net/misc/privacy-policy/"
-                rel="noreferrer"
-              >
-                Privacy
-              </a>
+              <a href="/documentation/misc/privacy-policy">Privacy</a>
             </li>
             <li>
               <a href="/contact">Contact</a>


### PR DESCRIPTION
The legal pages live under /documentation/misc/*, so link to them directly instead of sending users off to docs.2anki.net.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Terms of Service and Privacy Policy footer links to navigate internally instead of opening external pages in new tabs, improving navigation consistency within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->