### PR TITLE
style(about): rebuild page with shared design tokens

### DIFF
--- a/src/pages/AboutPage/AboutPage.module.css
+++ b/src/pages/AboutPage/AboutPage.module.css
@@ -1,95 +1,8 @@
-.page {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem;
-}
-
-.heroSection {
-  text-align: center;
-  padding: 2rem 0 3rem;
-}
-
-.heroTitle {
-  font-size: var(--text-3xl);
-  font-weight: var(--font-bold);
-  color: var(--color-text-primary);
-  margin: 0 0 0.5rem;
-}
-
-.heroSubtitle {
-  font-size: var(--text-base);
-  color: var(--color-text-secondary);
-  margin: 0;
-}
-
-.card {
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 2rem;
-  margin-bottom: 1.5rem;
-}
-
-.cardDark {
-  background: #1f2937;
-  border: 1px solid #374151;
-  border-radius: var(--radius-lg);
-  padding: 2rem;
-  color: #e5e7eb;
-}
-
-.cardDark h2 {
-  color: #f9fafb;
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  margin: 0 0 1rem;
-}
-
-.cardDark p {
-  line-height: 1.6;
-  margin: 0 0 1rem;
-}
-
-.cardDark p:last-child {
-  margin-bottom: 0;
-}
-
-.cardDark a {
-  color: #93c5fd;
-}
-
-.cardDark a:hover {
-  color: #bfdbfe;
-}
-
-.cardDark ul,
-.cardDark ol {
-  padding-left: 1.25rem;
-  margin: 0;
-}
-
-.cardDark li {
-  margin-bottom: 0.5rem;
-  line-height: 1.5;
-}
-
-.grid2 {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
-@media (max-width: 768px) {
-  .grid2 {
-    grid-template-columns: 1fr;
-  }
-}
-
 .ctaButton {
   display: inline-flex;
   align-items: center;
   padding: 0.625rem 1.5rem;
+  margin-top: 0.5rem;
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
   color: #fff;
@@ -102,10 +15,4 @@
 .ctaButton:hover {
   background: var(--color-primary-hover);
   color: #fff;
-}
-
-.smallText {
-  font-size: var(--text-xs);
-  color: #9ca3af;
-  margin-top: 1rem;
 }

--- a/src/pages/AboutPage/AboutPage.tsx
+++ b/src/pages/AboutPage/AboutPage.tsx
@@ -1,31 +1,31 @@
-import styles from './AboutPage.module.css';
-import sharedStyles from '../../styles/shared.module.css';
+import styles from '../../styles/shared.module.css';
+import pageStyles from './AboutPage.module.css';
 
 export default function AboutPage() {
   return (
     <div className={styles.page}>
-      <div className={styles.heroSection}>
-        <h1 className={styles.heroTitle}>About 2anki.net</h1>
-        <p className={styles.heroSubtitle}>
+      <header className={styles.pageHeaderCenter}>
+        <h1 className={styles.title}>About 2anki.net</h1>
+        <p className={styles.subtitle}>
           Making Anki flashcards easier, better, and faster
         </p>
-      </div>
+      </header>
 
-      <div className={styles.cardDark}>
-        <h2>What is 2anki?</h2>
+      <section className={`${styles.card} ${styles.marginBottomLg}`}>
+        <h2 className={styles.subHeading}>What is 2anki?</h2>
         <p>
-          2anki.net is a open source micro saas which takes Notion notes and
-          converts them to Anki flashcards. This project is used by autodidacts,
-          students and professionals around the world.
+          2anki.net is an open source micro-SaaS that converts Notion notes
+          into Anki flashcards. It is used by autodidacts, students and
+          professionals around the world.
         </p>
-        <p>Fast, simple, easy and open source!</p>
+        <p>Fast, simple, easy and open source.</p>
         <div className={styles.textCenter}>
-          <a href="/upload" className={styles.ctaButton}>
-            Get Started
+          <a href="/upload" className={pageStyles.ctaButton}>
+            Get started
           </a>
         </div>
-        <p className={sharedStyles.marginTopMd}>
-          The goal of the 2anki.net project is to provide a good way to make{' '}
+        <p className={styles.marginTopMd}>
+          The goal of 2anki.net is to provide a good way to make{' '}
           <a href="https://apps.ankiweb.net/" target="_blank" rel="noreferrer">
             Anki
           </a>{' '}
@@ -33,56 +33,52 @@ export default function AboutPage() {
           and easy ways to produce high quality flashcards. This project is a
           complement to Anki and Notion.
         </p>
-      </div>
+      </section>
 
-      <div className={styles.grid2}>
-        <div className={styles.cardDark}>
-          <h2>What We Are Not</h2>
+      <div className={`${styles.columns2} ${styles.marginBottomLg}`}>
+        <section className={styles.card}>
+          <h2 className={styles.subHeading}>What we are not</h2>
           <p>
             If you are looking for an Anki or Notion replacement then this
-            project is probably not right for you. We are never going to compete
-            against Anki in this project. We are building bridges
+            project is probably not right for you. We are never going to
+            compete against Anki — we are building bridges.
           </p>
           <p>
-            When that is said, if you are not content with Anki, you might want
-            to checkout{' '}
+            That said, if you are not content with Anki, you might want to
+            check out{' '}
             <a
               href="https://www.super-memory.com/"
               target="_blank"
               rel="noreferrer"
             >
               SuperMemo
-            </a>.
+            </a>
+            .
           </p>
-        </div>
+        </section>
 
-        <div className={styles.cardDark}>
-          <h2>Benefits</h2>
+        <section className={styles.card}>
+          <h2 className={styles.subHeading}>Benefits</h2>
           <ul>
             <li>
-              No technical skills required and free to use by anyone anywhere 🤗
+              No technical skills required and free to use by anyone, anywhere
+              🤗
             </li>
             <li>Convert your Notion toggle lists to Anki cards easily</li>
             <li>Support for embeds, audio files, images and more</li>
           </ul>
-          <p className={styles.smallText}>
-            * Please note that due to server costs, there are quota limits in
-            place but you can workaround this and self-host
+          <p className={styles.smallDescription}>
+            Due to server costs there are quota limits in place, but you can
+            work around this by self-hosting.
           </p>
-        </div>
+        </section>
       </div>
 
-      <div className={styles.cardDark}>
-        <h2>How it works</h2>
+      <section className={styles.card}>
+        <h2 className={styles.subHeading}>How it works</h2>
         <p>
           Check out our{' '}
-          <a
-            href="https://docs.2anki.net/guides/getting-started/"
-            target="_blank"
-            rel="noreferrer"
-          >
-            detailed guide
-          </a>{' '}
+          <a href="/documentation/guides/getting-started">detailed guide</a>{' '}
           or follow these simple steps:
         </p>
         <ol>
@@ -90,26 +86,24 @@ export default function AboutPage() {
           <li>Export and upload to 2anki.net</li>
           <li>Download and import into Anki</li>
         </ol>
-        <div className={sharedStyles.marginTopXl}>
-          <p>
-            We treat toggle lists on the top level as Anki flashcards. The
-            toggle list line is the front of the card and everything inside in
-            the details is the back. That&apos;s the main feature but you can
-            customize the behaviour via card options.
-          </p>
-          <p>
-            Considering how powerful{' '}
-            <a
-              href="https://docs.ankiweb.net/#/editing?id=cloze-deletion"
-              target="_blank"
-              rel="noreferrer"
-            >
-              cloze deletions
-            </a>{' '}
-            are, they are enabled by default.
-          </p>
-        </div>
-      </div>
+        <p className={styles.marginTopLg}>
+          Toggle lists at the top level become Anki flashcards. The toggle
+          line is the front of the card and everything inside the details is
+          the back. That is the main feature, but you can customise the
+          behaviour via card options.
+        </p>
+        <p>
+          Considering how powerful{' '}
+          <a
+            href="https://docs.ankiweb.net/#/editing?id=cloze-deletion"
+            target="_blank"
+            rel="noreferrer"
+          >
+            cloze deletions
+          </a>{' '}
+          are, they are enabled by default.
+        </p>
+      </section>
     </div>
   );
 }

--- a/src/pages/HomePage/components/VideosAndDocs.tsx
+++ b/src/pages/HomePage/components/VideosAndDocs.tsx
@@ -5,9 +5,7 @@ export function VideosAndDocs() {
     <>
       <p>
         Checkout these videos on how to get started or read the documentation on{' '}
-        <a href="https://docs.2anki.net/guides/getting-started/">
-          getting started
-        </a>!
+        <a href="/documentation/guides/getting-started">getting started</a>!
       </p>
 
       <h3 className={styles.sectionHeading}>


### PR DESCRIPTION
Swap the dark hardcoded cards for the shared light card, page, and typography styles used elsewhere in the app. Also redirect the two "getting started" links from docs.2anki.net to the in-app docs route.