### PR TITLE
fix(routing): guard authenticated routes and prevent login redirect loop 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { lazy, useState } from 'react';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { lazy, ReactElement, useState } from 'react';
 
 import { useCookies, CookiesProvider } from 'react-cookie';
 import UploadPage from './pages/UploadPage';
@@ -16,6 +16,7 @@ import DeleteAccountPage from './pages/DeleteAccountPage';
 import { getErrorMessage } from './components/errors/helpers/getErrorMessage';
 import { sendError } from './lib/SendError';
 import { useUserLocals } from './lib/hooks/useUserLocals';
+import LoadingIndicator from './components/Loading';
 import NotFoundPage from './pages/NotFoundPage';
 
 const RegisterPage = lazy(() => import('./pages/RegisterPage'));
@@ -35,6 +36,24 @@ const RulesPage = lazy(() => import('./pages/RulesPage'));
 
 const queryClient = new QueryClient();
 
+function RequireAuth({
+  isLoggedIn,
+  isLoading,
+  children,
+}: Readonly<{
+  isLoggedIn: boolean;
+  isLoading: boolean;
+  children: ReactElement;
+}>) {
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+  if (!isLoggedIn) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}
+
 function AppContent({
   error,
   setErrorMessage,
@@ -47,17 +66,28 @@ function AppContent({
   const isLoggedIn = !isLoading && !!data?.user?.id;
   const isPaying =
     !isLoading && (!!data?.locals?.patreon || !!data?.locals?.subscriber);
+
+  const requireAuth = (element: ReactElement) => (
+    <RequireAuth isLoggedIn={isLoggedIn} isLoading={isLoading}>
+      {element}
+    </RequireAuth>
+  );
+
   return (
     <BrowserRouter>
       <PageLayout error={error} isLoggedIn={isLoggedIn} isPaying={isPaying}>
         <Routes>
           <Route
             path="/favorites"
-            element={<FavoritesPage setError={setErrorMessage} />}
+            element={requireAuth(
+              <FavoritesPage setError={setErrorMessage} />
+            )}
           />
           <Route
             path="/uploads"
-            element={<DownloadsPage setError={setErrorMessage} />}
+            element={requireAuth(
+              <DownloadsPage setError={setErrorMessage} />
+            )}
           />
           <Route
             path="/upload"
@@ -69,7 +99,9 @@ function AppContent({
           />
           <Route
             path="/search"
-            element={<SearchPage setError={setErrorMessage} />}
+            element={requireAuth(
+              <SearchPage setError={setErrorMessage} />
+            )}
           />
           <Route path="/login" element={<LoginPage />} />
           <Route
@@ -84,7 +116,9 @@ function AppContent({
           <Route path="/contact" element={<ContactPage />} />
           <Route
             path="/delete-account"
-            element={<DeleteAccountPage setError={setErrorMessage} />}
+            element={requireAuth(
+              <DeleteAccountPage setError={setErrorMessage} />
+            )}
           />
           <Route
             path="/pricing"
@@ -103,18 +137,22 @@ function AppContent({
             path="/successful-checkout"
             element={<SuccessfulCheckoutPage />}
           />
-          <Route path="/account" element={<AccountPage />} />
-          <Route path="/settings" element={<AccountPage />} />
+          <Route path="/account" element={requireAuth(<AccountPage />)} />
+          <Route path="/settings" element={requireAuth(<AccountPage />)} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/documentation" element={<DocsPage />} />
           <Route path="/documentation/*" element={<DocsPage />} />
           <Route
             path="/settings/card-options"
-            element={<CardOptionsPage setErrorMessage={setErrorMessage} />}
+            element={requireAuth(
+              <CardOptionsPage setErrorMessage={setErrorMessage} />
+            )}
           />
           <Route
             path="/rules/:id"
-            element={<RulesPage setErrorMessage={setErrorMessage} />}
+            element={requireAuth(
+              <RulesPage setErrorMessage={setErrorMessage} />
+            )}
           />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/lib/backend/api.ts
+++ b/src/lib/backend/api.ts
@@ -5,6 +5,18 @@ interface ClientSideOptions {
   redirect?: boolean;
 }
 
+const AUTH_PATHS = ['/login', '/register', '/forgot', '/users/r/'];
+
+function redirectToLogin() {
+  const currentPath = globalThis.location?.pathname ?? '';
+  const alreadyOnAuthPage = AUTH_PATHS.some((prefix) =>
+    currentPath.startsWith(prefix)
+  );
+  if (!alreadyOnAuthPage) {
+    globalThis.location.href = '/login';
+  }
+}
+
 export const getLoginURL = (baseURL: string) => `${baseURL}users/login`;
 
 export const post = async (url: string, body: unknown) =>
@@ -32,7 +44,7 @@ export const get = async (
 
   if (!response.ok) {
     if (response.status === UNAUTHORIZED) {
-      window.location.href = '/login';
+      redirectToLogin();
       return undefined;
     }
     if (response.status === NOT_FOUND) {

--- a/src/lib/backend/cancelSubscription.test.ts
+++ b/src/lib/backend/cancelSubscription.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cancelSubscription } from './cancelSubscription';
+import * as api from './api';
+
+vi.mock('./api', () => ({
+  post: vi.fn(),
+}));
+
+const createMockResponse = (
+  status: number,
+  jsonData: unknown,
+  statusText = ''
+): Response =>
+  ({
+    status,
+    statusText,
+    json: vi.fn().mockResolvedValue(jsonData),
+  }) as unknown as Response;
+
+describe('cancelSubscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the success payload on 200', async () => {
+    vi.mocked(api.post).mockResolvedValue(
+      createMockResponse(200, { message: 'scheduled' })
+    );
+
+    await expect(cancelSubscription()).resolves.toEqual({
+      message: 'scheduled',
+    });
+  });
+
+  it('defaults mode to period_end when called without args', async () => {
+    vi.mocked(api.post).mockResolvedValue(
+      createMockResponse(200, { message: 'ok' })
+    );
+
+    await cancelSubscription();
+
+    expect(api.post).toHaveBeenCalledWith(
+      '/api/users/cancel-subscription',
+      { mode: 'period_end' }
+    );
+  });
+
+  it('sends the requested mode in the body', async () => {
+    vi.mocked(api.post).mockResolvedValue(
+      createMockResponse(200, { message: 'ok' })
+    );
+
+    await cancelSubscription('immediate');
+
+    expect(api.post).toHaveBeenCalledWith(
+      '/api/users/cancel-subscription',
+      { mode: 'immediate' }
+    );
+  });
+
+  it('throws the server message from a JSON error body', async () => {
+    vi.mocked(api.post).mockResolvedValue(
+      createMockResponse(
+        404,
+        { message: 'No active subscription found' },
+        'Not Found'
+      )
+    );
+
+    await expect(cancelSubscription()).rejects.toThrow(
+      'No active subscription found'
+    );
+  });
+
+  it('falls back to statusText when no JSON message is present', async () => {
+    vi.mocked(api.post).mockResolvedValue(
+      createMockResponse(500, {}, 'Internal Server Error')
+    );
+
+    await expect(cancelSubscription()).rejects.toThrow(
+      'Internal Server Error'
+    );
+  });
+});

--- a/src/lib/backend/cancelSubscription.ts
+++ b/src/lib/backend/cancelSubscription.ts
@@ -1,26 +1,28 @@
 import { post } from './api';
 
 const UNAUTHORIZED = 401;
+const OK = 200;
 
-export const cancelSubscription = async (): Promise<{ message: string }> => {
-  try {
-    const response = await post('/api/users/cancel-subscription', {});
-    if (response?.status === UNAUTHORIZED) {
-      globalThis.location.href = '/login';
-      throw new Error('Authentication required');
-    }
-    if (response?.status !== 200) {
-      throw new Error(
-        `Failed to cancel subscription: ${
-          response?.statusText || 'Unknown error'
-        }`
-      );
-    }
-    return await response.json();
-  } catch (error) {
-    if (error instanceof Error) {
-      throw error;
-    }
-    throw new Error('An unexpected error occurred');
+export type CancelMode = 'immediate' | 'period_end';
+
+export const cancelSubscription = async (
+  mode: CancelMode = 'period_end'
+): Promise<{ message: string }> => {
+  const response = await post('/api/users/cancel-subscription', { mode });
+
+  if (response?.status === UNAUTHORIZED) {
+    globalThis.location.href = '/login';
+    throw new Error('Authentication required');
   }
+
+  if (response?.status !== OK) {
+    const fallback = response?.statusText || 'Unknown error';
+    const message = await response
+      ?.json()
+      .then((body: { message?: string }) => body?.message ?? fallback)
+      .catch(() => fallback);
+    throw new Error(message);
+  }
+
+  return response.json();
 };

--- a/src/lib/backend/getSubscriptionStatus.ts
+++ b/src/lib/backend/getSubscriptionStatus.ts
@@ -1,0 +1,26 @@
+import { get } from './api';
+
+export interface StripePlanSummary {
+  amount: number | null;
+  currency: string | null;
+  interval: string | null;
+}
+
+export interface StripeSubscriptionSummary {
+  id: string;
+  status: string;
+  cancel_at_period_end: boolean;
+  current_period_end: number | null;
+  canceled_at: number | null;
+  plan: StripePlanSummary | null;
+}
+
+export interface SubscriptionStatusResponse {
+  subscriptions: StripeSubscriptionSummary[];
+}
+
+export const getSubscriptionStatus =
+  async (): Promise<SubscriptionStatusResponse> => {
+    const data = await get('/api/users/subscription-status');
+    return data ?? { subscriptions: [] };
+  };

--- a/src/lib/hooks/useStripeSubscriptions.ts
+++ b/src/lib/hooks/useStripeSubscriptions.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getSubscriptionStatus,
+  StripeSubscriptionSummary,
+} from '../backend/getSubscriptionStatus';
+
+export type SubscriptionViewState =
+  | { kind: 'none' }
+  | { kind: 'active'; subscription: StripeSubscriptionSummary }
+  | { kind: 'scheduled'; subscription: StripeSubscriptionSummary }
+  | { kind: 'cancelled'; subscription: StripeSubscriptionSummary };
+
+export interface StripeSubscriptionsState {
+  subscriptions: StripeSubscriptionSummary[];
+  view: SubscriptionViewState;
+  isLoading: boolean;
+  refetch: () => Promise<unknown>;
+}
+
+function deriveView(
+  subscriptions: StripeSubscriptionSummary[]
+): SubscriptionViewState {
+  const active = subscriptions.find((sub) => sub.status === 'active');
+  if (active) {
+    return active.cancel_at_period_end
+      ? { kind: 'scheduled', subscription: active }
+      : { kind: 'active', subscription: active };
+  }
+
+  const cancelled = subscriptions.find((sub) => sub.status === 'canceled');
+  if (cancelled) {
+    return { kind: 'cancelled', subscription: cancelled };
+  }
+
+  return { kind: 'none' };
+}
+
+export function useStripeSubscriptions(
+  enabled: boolean
+): StripeSubscriptionsState {
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['stripeSubscriptions'],
+    queryFn: getSubscriptionStatus,
+    enabled,
+    staleTime: 15_000,
+  });
+
+  const subscriptions = data?.subscriptions ?? [];
+
+  return {
+    subscriptions,
+    view: deriveView(subscriptions),
+    isLoading,
+    refetch,
+  };
+}

--- a/src/pages/AccountPage/AccountPage.module.css
+++ b/src/pages/AccountPage/AccountPage.module.css
@@ -44,17 +44,6 @@
   margin: 0 0 0.5rem;
 }
 
-.statusBadge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.75rem;
-  font-size: var(--text-xs);
-  font-weight: var(--font-medium);
-  color: var(--color-primary);
-  background: var(--color-primary-light);
-  border-radius: var(--radius-full);
-}
-
 .sectionTitle {
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
@@ -216,4 +205,41 @@
 .secondaryButton:hover {
   background: var(--color-bg-secondary);
   color: var(--color-text-primary);
+}
+
+.scheduledBadge {
+  padding: 0.75rem 1rem;
+  background: var(--color-warning-light, #fef3c7);
+  border: 1px solid var(--color-warning-border, #fcd34d);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: var(--color-warning-text, #92400e);
+  margin-bottom: 0.75rem;
+}
+
+.activeBadge {
+  padding: 0.75rem 1rem;
+  background: var(--color-success-light, #d1fae5);
+  border: 1px solid #a7f3d0;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: #065f46;
+  margin-bottom: 0.75rem;
+}
+
+.cancelledBadge {
+  padding: 0.75rem 1rem;
+  background: var(--color-bg-secondary, #f3f4f6);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary, #4b5563);
+  margin-bottom: 0.75rem;
+}
+
+.planDetail {
+  margin: 0.25rem 0 0;
+  font-size: var(--text-xs);
+  color: inherit;
+  opacity: 0.85;
 }

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -14,8 +14,9 @@ import styles from './AccountPage.module.css';
 
 export default function AccountPage() {
   const { isLoading, data, refetch } = useUserLocals();
-  const { subscriptionStatus, subscriptionType, hasActivePlan } =
-    useSubscriptionStatus(data?.locals);
+  const { subscriptionType, hasActivePlan } = useSubscriptionStatus(
+    data?.locals
+  );
   const notionData = useNotionData(get2ankiApi());
 
   if (isLoading) return <LoadingIndicator />;
@@ -37,7 +38,7 @@ export default function AccountPage() {
       </header>
 
       <div className={styles.mainCard}>
-        <UserProfile user={user} subscriptionStatus={subscriptionStatus} />
+        <UserProfile user={user} />
 
         <h2 className={styles.sectionTitle}>Plan details</h2>
         <PlanDetails subscriptionType={subscriptionType} />

--- a/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -1,6 +1,8 @@
 import React, { ChangeEvent, useEffect } from 'react';
 import { useEmailLinking } from '../hooks/useEmailLinking';
 import { useSubscriptionCancellation } from '../hooks/useSubscriptionCancellation';
+import { useStripeSubscriptions } from '../../../lib/hooks/useStripeSubscriptions';
+import { StripeSubscriptionSummary } from '../../../lib/backend/getSubscriptionStatus';
 import styles from '../AccountPage.module.css';
 import sharedStyles from '../../../styles/shared.module.css';
 
@@ -25,6 +27,25 @@ interface SubscriptionManagementProps {
   readonly onRefetch: () => Promise<any>;
 }
 
+const formatDate = (seconds: number | null): string => {
+  if (!seconds) return 'an unknown date';
+  return new Date(seconds * 1000).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};
+
+const formatPlan = (sub: StripeSubscriptionSummary): string | null => {
+  const plan = sub.plan;
+  if (!plan || plan.amount == null || !plan.currency) return null;
+  const price = (plan.amount / 100).toLocaleString(undefined, {
+    style: 'currency',
+    currency: plan.currency.toUpperCase(),
+  });
+  return plan.interval ? `${price} / ${plan.interval}` : price;
+};
+
 export function SubscriptionManagement({
   user,
   locals,
@@ -40,8 +61,18 @@ export function SubscriptionManagement({
     performLinkEmail,
   } = useEmailLinking(onRefetch);
 
-  const { cancelUserSubscription, isCancelling } =
-    useSubscriptionCancellation(onRefetch);
+  const stripeStatus = useStripeSubscriptions(Boolean(locals?.subscriber));
+
+  const refetchAll = async () => {
+    await Promise.all([onRefetch(), stripeStatus.refetch()]);
+  };
+
+  const {
+    cancelUserSubscription,
+    isCancelling,
+    cancelError,
+    cancelSuccess,
+  } = useSubscriptionCancellation(refetchAll);
 
   useEffect(() => {
     if (locals?.subscriptionInfo?.linked_email) {
@@ -63,23 +94,99 @@ export function SubscriptionManagement({
     return null;
   }
 
+  const { view } = stripeStatus;
+
   return (
     <div className={styles.managementCard}>
       <h3 className={styles.managementTitle}>Subscription Management</h3>
       {locals?.subscriber && (
         <div className={sharedStyles.marginBottomMd}>
-          <p className={sharedStyles.smallDescription}>
-            Manage your active subscription. You can cancel anytime and will
-            retain access until the end of your current billing period.
-          </p>
-          <button
-            type="button"
-            className={styles.dangerButton}
-            onClick={cancelUserSubscription}
-            disabled={isCancelling}
-          >
-            {isCancelling ? 'Cancelling...' : 'Cancel Subscription'}
-          </button>
+          {view.kind === 'active' && (
+            <div className={styles.activeBadge}>
+              Active — renews on{' '}
+              <strong>{formatDate(view.subscription.current_period_end)}</strong>
+              .
+              {formatPlan(view.subscription) && (
+                <p className={styles.planDetail}>
+                  {formatPlan(view.subscription)}
+                </p>
+              )}
+            </div>
+          )}
+
+          {view.kind === 'scheduled' && (
+            <div className={styles.scheduledBadge}>
+              Scheduled to cancel on{' '}
+              <strong>{formatDate(view.subscription.current_period_end)}</strong>
+              . You will keep access until then.
+              {formatPlan(view.subscription) && (
+                <p className={styles.planDetail}>
+                  {formatPlan(view.subscription)}
+                </p>
+              )}
+            </div>
+          )}
+
+          {view.kind === 'cancelled' && (
+            <div className={styles.cancelledBadge}>
+              Cancelled on{' '}
+              <strong>{formatDate(view.subscription.canceled_at)}</strong>. Your
+              subscription is no longer active.
+              {formatPlan(view.subscription) && (
+                <p className={styles.planDetail}>
+                  Previous plan: {formatPlan(view.subscription)}
+                </p>
+              )}
+            </div>
+          )}
+
+          {view.kind === 'none' && stripeStatus.isLoading && (
+            <p className={sharedStyles.smallDescription}>
+              Loading subscription status…
+            </p>
+          )}
+
+          <div className={styles.buttonRow}>
+            {view.kind === 'active' && (
+              <>
+                <button
+                  type="button"
+                  className={styles.dangerButton}
+                  onClick={() => cancelUserSubscription('period_end')}
+                  disabled={isCancelling}
+                >
+                  {isCancelling
+                    ? 'Processing…'
+                    : 'Cancel at end of billing period'}
+                </button>
+                <button
+                  type="button"
+                  className={styles.dangerButton}
+                  onClick={() => cancelUserSubscription('immediate')}
+                  disabled={isCancelling}
+                >
+                  {isCancelling ? 'Processing…' : 'Cancel immediately'}
+                </button>
+              </>
+            )}
+            {view.kind === 'scheduled' && (
+              <button
+                type="button"
+                className={styles.dangerButton}
+                onClick={() => cancelUserSubscription('immediate')}
+                disabled={isCancelling}
+              >
+                {isCancelling ? 'Processing…' : 'Cancel immediately instead'}
+              </button>
+            )}
+          </div>
+
+          {cancelError && (
+            <p className={styles.helpDanger}>{cancelError}</p>
+          )}
+          {cancelSuccess && (
+            <p className={styles.helpSuccess}>{cancelSuccess}</p>
+          )}
         </div>
       )}
 

--- a/src/pages/AccountPage/components/UserProfile.tsx
+++ b/src/pages/AccountPage/components/UserProfile.tsx
@@ -8,10 +8,9 @@ interface User {
 
 interface UserProfileProps {
   readonly user: User;
-  readonly subscriptionStatus: string;
 }
 
-export function UserProfile({ user, subscriptionStatus }: UserProfileProps) {
+export function UserProfile({ user }: UserProfileProps) {
   return (
     <div className={styles.profileSection}>
       <div className={styles.profileInfo}>
@@ -21,7 +20,6 @@ export function UserProfile({ user, subscriptionStatus }: UserProfileProps) {
         <p className={styles.profileEmail} data-hj-suppress>
           {user.email}
         </p>
-        <span className={styles.statusBadge}>{subscriptionStatus}</span>
       </div>
     </div>
   );

--- a/src/pages/AccountPage/hooks/useSubscriptionCancellation.ts
+++ b/src/pages/AccountPage/hooks/useSubscriptionCancellation.ts
@@ -1,40 +1,49 @@
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { cancelSubscription } from '../../../lib/backend/cancelSubscription';
+import {
+  cancelSubscription,
+  CancelMode,
+} from '../../../lib/backend/cancelSubscription';
+
+const CONFIRM_MESSAGES: Record<CancelMode, string> = {
+  period_end:
+    'Are you sure you want to cancel your subscription? You will still have access until the end of your current billing period.',
+  immediate:
+    'Are you sure you want to cancel your subscription immediately? You will lose access right away and will not be refunded the remainder of the current period.',
+};
 
 export function useSubscriptionCancellation(onSuccess?: () => void) {
-  const [isCancelling, setIsCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState<string>('');
+  const [cancelSuccess, setCancelSuccess] = useState<string>('');
 
-  const { mutate: performCancellation, isPending } = useMutation({
-    mutationFn: cancelSubscription,
-    onMutate: () => {
-      setIsCancelling(true);
-    },
-    onSuccess: () => {
-      setIsCancelling(false);
+  const { mutate, isPending: isCancelling } = useMutation({
+    mutationFn: (mode: CancelMode) => cancelSubscription(mode),
+    onSuccess: (data) => {
+      setCancelError('');
+      setCancelSuccess(
+        data?.message ??
+          'Your subscription change has been processed.'
+      );
       onSuccess?.();
     },
-    onError: (error: any) => {
-      setIsCancelling(false);
-      const errorMessage =
-        error?.response?.data?.message ?? 'Failed to cancel subscription';
-      console.error('Subscription cancellation failed:', errorMessage);
-      // Could show error notification here if needed
+    onError: (error: Error) => {
+      setCancelSuccess('');
+      setCancelError(error?.message || 'Failed to cancel subscription');
     },
   });
 
-  const cancelUserSubscription = () => {
-    if (
-      globalThis.confirm(
-        'Are you sure you want to cancel your subscription? You will still have access until the end of your current billing period.'
-      )
-    ) {
-      performCancellation();
+  const cancelUserSubscription = (mode: CancelMode = 'period_end') => {
+    if (globalThis.confirm(CONFIRM_MESSAGES[mode])) {
+      setCancelError('');
+      setCancelSuccess('');
+      mutate(mode);
     }
   };
 
   return {
     cancelUserSubscription,
-    isCancelling: isPending || isCancelling,
+    isCancelling,
+    cancelError,
+    cancelSuccess,
   };
 }

--- a/src/pages/AccountPage/hooks/useSubscriptionStatus.ts
+++ b/src/pages/AccountPage/hooks/useSubscriptionStatus.ts
@@ -8,12 +8,6 @@ interface UserLocals {
 type SubscriptionType = 'subscriber' | 'lifetime' | 'free';
 
 export function useSubscriptionStatus(locals: UserLocals | undefined) {
-  const subscriptionStatus = useMemo(() => {
-    if (locals?.subscriber) return 'Active Subscriber';
-    if (locals?.patreon) return 'Lifetime Member';
-    return 'Free Plan';
-  }, [locals?.subscriber, locals?.patreon]);
-
   const subscriptionType = useMemo((): SubscriptionType => {
     if (locals?.subscriber) return 'subscriber';
     if (locals?.patreon) return 'lifetime';
@@ -25,7 +19,6 @@ export function useSubscriptionStatus(locals: UserLocals | undefined) {
   }, [locals?.subscriber, locals?.patreon]);
 
   return {
-    subscriptionStatus,
     subscriptionType,
     hasActivePlan,
   };


### PR DESCRIPTION
Every route in App.tsx rendered unconditionally, so anonymous visitors
could load /favorites, /account, /search, /settings, /rules/:id and
/delete-account — the pages only appeared broken once the underlying
API call came back with no data. Introduce a RequireAuth wrapper that
waits for useUserLocals to resolve, then either renders the page or
redirects to /login when there is no user.

Also tighten the api.ts get() helper: when a 401 comes back while the
user is already on /login, /register, /forgot or /users/r/*, skip the
window.location redirect so background 401s can't push the page into
a reload loop.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>