### PR TITLE
feat(search): add privacy trust line under Notion connect button

### DIFF
--- a/src/pages/SearchPage/components/ConnectNotion.tsx
+++ b/src/pages/SearchPage/components/ConnectNotion.tsx
@@ -22,6 +22,10 @@ export default function ConnectNotion({ ready, connectionLink }: Props) {
         <a className={styles.btnPrimary} href={connectionLink}>
           Connect
         </a>
+        <p className={styles.smallDescription}>
+          We only read the pages you select. We don&apos;t store your Notion
+          content.
+        </p>
       </div>
       <div className={styles.sectionCard}>
         <h3 className={styles.sectionTitle}>Manual File Upload</h3>


### PR DESCRIPTION
## Summary
- Adds one short line of muted copy under the Notion "Connect" button: *"We only read the pages you select. We don't store your Notion content."*
- Addresses user feedback: several users hesitate to connect their workspace due to privacy concerns, but are fine once they try it — the doubt costs conversions.
- Uses the existing `.smallDescription` style to match helper text elsewhere in the app.

## Test plan
- [x] Visit `/search` while not connected → see the new line between the Connect button and the "Manual File Upload" card.
- [x] Verify styling matches other helper text.
- [x] `pnpm test --run` and `pnpm exec tsc --noEmit` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)