### PR TITLE
fix(errors): map raw errors to friendly copy and add retry button

### DIFF
--- a/src/components/TopMessage/TopMessage.tsx
+++ b/src/components/TopMessage/TopMessage.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import useQuery from '../../lib/hooks/useQuery';
 import styles from '../../styles/shared.module.css';
 
@@ -8,7 +9,10 @@ function TopMessage() {
   if (errorMessage === 'upload_limit_exceeded') {
     return (
       <div className={styles.alertDanger}>
-        <p>You have reached the upload limit of 100 flashcards.</p>
+        <p>
+          You&apos;ve reached your conversion limit.{' '}
+          <Link to="/pricing">Upgrade</Link> to convert more.
+        </p>
       </div>
     );
   }

--- a/src/components/errors/ErrorPresenter.tsx
+++ b/src/components/errors/ErrorPresenter.tsx
@@ -1,30 +1,48 @@
-import { getErrorMessage } from './helpers/getErrorMessage';
+import { classifyError } from './helpers/getErrorMessage';
 import { useDismissed } from './helpers/useDismissed';
 import styles from '../../styles/shared.module.css';
 
 interface ErrorPresenterProps {
   error: unknown;
+  onRetry?: () => void;
 }
 
-export function ErrorPresenter({ error }: ErrorPresenterProps) {
+export function ErrorPresenter({ error, onRetry }: ErrorPresenterProps) {
   const { dismissed, setDismissed } = useDismissed(error);
 
   if (!error || dismissed) {
     return null;
   }
 
+  const { title, detail } = classifyError(error);
+
   return (
     <article className={styles.alertInfo}>
       <div className={styles.modalBody}>
-        <div dangerouslySetInnerHTML={{ __html: getErrorMessage(error) }} />
+        <p>
+          <strong>{title}</strong>
+        </p>
+        {detail && <p className={styles.smallDescription}>{detail}</p>}
       </div>
       <div className={styles.modalFooter}>
+        {onRetry && (
+          <button
+            type="button"
+            className={styles.btnPrimary}
+            onClick={() => {
+              setDismissed(true);
+              onRetry();
+            }}
+          >
+            Try again
+          </button>
+        )}
         <button
           type="button"
           className={styles.btnSecondary}
           onClick={() => setDismissed(true)}
         >
-          Close
+          Dismiss
         </button>
       </div>
     </article>

--- a/src/components/errors/helpers/getErrorMessage.test.ts
+++ b/src/components/errors/helpers/getErrorMessage.test.ts
@@ -1,0 +1,56 @@
+import { classifyError, getErrorMessage } from './getErrorMessage';
+
+describe('classifyError', () => {
+  test('TypeError: Failed to fetch is a network error', () => {
+    const err = new TypeError('Failed to fetch');
+    expect(classifyError(err).title).toMatch(/couldn't reach 2anki/i);
+  });
+
+  test('unauthorized message prompts sign-in', () => {
+    expect(classifyError(new Error('unauthorized')).title).toMatch(
+      /sign in again/i
+    );
+  });
+
+  test('object_not_found gives a Notion-specific hint', () => {
+    expect(classifyError(new Error('object_not_found')).detail).toMatch(
+      /Notion/i
+    );
+  });
+
+  test('upload_limit_exceeded suggests upgrading', () => {
+    expect(
+      classifyError(new Error('upload_limit_exceeded')).detail
+    ).toMatch(/pricing/i);
+  });
+
+  test('rate_limited tells the user to wait', () => {
+    expect(classifyError(new Error('rate_limited')).title).toMatch(
+      /too many/i
+    );
+  });
+
+  test('falls back to a short server message when one is provided', () => {
+    expect(classifyError(new Error('No active subscription.')).title).toBe(
+      'No active subscription.'
+    );
+  });
+
+  test('unknown/empty error yields generic fallback', () => {
+    expect(classifyError(undefined).title).toMatch(/Something went wrong/i);
+  });
+
+  test('HTML-looking long blobs fall back rather than leaking markup', () => {
+    const ugly = '<html><body>big raw stack trace…</body></html>'.repeat(20);
+    expect(classifyError(new Error(ugly)).title).toMatch(
+      /Something went wrong/i
+    );
+  });
+});
+
+describe('getErrorMessage', () => {
+  test('returns plain text — no HTML', () => {
+    const msg = getErrorMessage(new Error('Failed to fetch'));
+    expect(msg).not.toMatch(/</);
+  });
+});

--- a/src/components/errors/helpers/getErrorMessage.ts
+++ b/src/components/errors/helpers/getErrorMessage.ts
@@ -1,11 +1,99 @@
 export type ErrorHandlerType = (error: unknown) => void;
 
-export const getErrorMessage = (error: unknown): string => {
-  let msg = 'Unknown error';
-  if (error instanceof Error) {
-    msg = `<h1 class='title is-4'>${error.message}</h1>`;
-  } else if (typeof error === 'string') {
-    return error;
+interface FriendlyError {
+  title: string;
+  detail?: string;
+}
+
+const FALLBACK: FriendlyError = {
+  title: 'Something went wrong.',
+  detail: 'Please try again. If the problem keeps happening, email support@2anki.net.',
+};
+
+function toText(error: unknown): string {
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const m = (error as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
   }
-  return msg;
+  return '';
+}
+
+export function classifyError(error: unknown): FriendlyError {
+  const raw = toText(error);
+
+  if (!raw) return FALLBACK;
+
+  const lower = raw.toLowerCase();
+
+  // Network / offline — Chrome's fetch throws "TypeError: Failed to fetch"
+  if (
+    error instanceof TypeError ||
+    lower.includes('failed to fetch') ||
+    lower.includes('networkerror') ||
+    lower.includes('load failed')
+  ) {
+    return {
+      title: "We couldn't reach 2anki.",
+      detail: 'Please check your connection and try again.',
+    };
+  }
+
+  if (
+    lower.includes('econnreset') ||
+    lower.includes('etimedout') ||
+    lower.includes('econnrefused') ||
+    lower.includes('gateway_timeout') ||
+    lower.includes('service_unavailable')
+  ) {
+    return {
+      title: 'The service is unreachable right now.',
+      detail: 'This is usually temporary — try again in a moment.',
+    };
+  }
+
+  if (lower.includes('rate_limited') || lower.includes('429')) {
+    return {
+      title: 'Too many requests.',
+      detail:
+        "We're throttled by the upstream service. Please try again in a minute.",
+    };
+  }
+
+  if (lower.includes('unauthorized') || lower.includes('401')) {
+    return {
+      title: 'Please sign in again.',
+      detail: 'Your session has expired.',
+    };
+  }
+
+  if (lower.includes('object_not_found') || lower.includes('404')) {
+    return {
+      title: "We couldn't find that page.",
+      detail:
+        'It may have been deleted in Notion, or access was revoked. Try reconnecting or choosing a different page.',
+    };
+  }
+
+  if (lower.includes('upload_limit') || lower.includes('upload limit')) {
+    return {
+      title: "You've reached your conversion limit.",
+      detail: 'Upgrade your plan at /pricing to convert more decks.',
+    };
+  }
+
+  // Server-provided message — trust it, it was already JSON { message: "..." }
+  if (raw.length > 0 && raw.length < 280 && !raw.startsWith('<')) {
+    return { title: raw };
+  }
+
+  return FALLBACK;
+}
+
+export const getErrorMessage = (error: unknown): string => {
+  const friendly = classifyError(error);
+  return friendly.detail
+    ? `${friendly.title} ${friendly.detail}`
+    : friendly.title;
 };

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -31,7 +31,9 @@ export function SearchPage({ setError }: SearchPageProps) {
       </div>
     );
   } else if (notionData.error) {
-    content = <ErrorPresenter error={notionData.error} />;
+    content = (
+      <ErrorPresenter error={notionData.error} onRetry={notionData.refetch} />
+    );
   } else if (!notionData.connected) {
     content = (
       <ConnectNotion

--- a/src/pages/SearchPage/helpers/useNotionData.tsx
+++ b/src/pages/SearchPage/helpers/useNotionData.tsx
@@ -9,7 +9,9 @@ export interface NotionData {
   error?: Error;
 }
 
-export default function useNotionData(backend: Backend): NotionData {
+export default function useNotionData(
+  backend: Backend
+): NotionData & { refetch: () => void } {
   const [state, setState] = useState<NotionData>(() => ({
     loading: true,
     workSpace: localStorage.getItem('__workspace'),
@@ -44,5 +46,8 @@ export default function useNotionData(backend: Backend): NotionData {
     }
   }, [state.loading]);
 
-  return state;
+  const refetch = () =>
+    setState((prev) => ({ ...prev, loading: true, error: undefined }));
+
+  return { ...state, refetch };
 }


### PR DESCRIPTION
## Summary
Users were seeing raw error strings like *"Failed to fetch"* and *"unauthorized"* with no guidance.

- New `classifyError()` maps incoming errors (TypeError, Notion error codes, HTTP-like statuses, upload-limit) to `{ title, detail }` with actionable copy.
- `ErrorPresenter` renders that + an optional **Try again** button when an `onRetry` callback is provided. No more `dangerouslySetInnerHTML`.
- Short server messages (`{ message: "..." }`) still pass through; long / HTML-looking blobs collapse to a generic fallback so a raw stack trace can never leak.
- `SearchPage` now wires a retry via a new `refetch()` on `useNotionData`.
- `TopMessage` upload-limit copy no longer says "100 flashcards" (stale number) and now links to `/pricing`.

## Key copy changes
| Before | After |
| --- | --- |
| `Failed to fetch` | **We couldn't reach 2anki.** Please check your connection and try again. |
| `unauthorized` | **Please sign in again.** Your session has expired. |
| `object_not_found` | **We couldn't find that page.** It may have been deleted in Notion, or access was revoked. Try reconnecting or choosing a different page. |
| `rate_limited` | **Too many requests.** We're throttled by the upstream service. Please try again in a minute. |
| `You have reached the upload limit of 100 flashcards.` | **You've reached your conversion limit.** [Upgrade](/pricing) to convert more. |

## Test plan
- [x] `pnpm test --run` — 30 pass (9 new for `classifyError`).
- [x] `pnpm exec tsc --noEmit` — clean.
- [ ] Manual: disconnect network, reload a page that calls Notion → network copy appears with Try again button.
- [ ] Manual: visit `/something?error=upload_limit_exceeded` → see new copy with pricing link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)