### PR TITLE
feat(card-options): explain toggle-to-card mapping inline

### DIFF
--- a/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -384,9 +384,24 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
         </div>
 
         <div className={fieldStyles.section}>
+          <p className={fieldStyles.sectionHint}>
+            <strong>How toggles become cards:</strong> each toggle&apos;s header
+            is the front of a card, and its contents become the back. A toggle
+            inside a toggle (nested toggle) becomes its own card using the
+            rules below.
+          </p>
+        </div>
+
+        <div className={fieldStyles.section}>
           <label htmlFor="toggle-mode" className={fieldStyles.sectionLabel}>
             Toggle Mode
           </label>
+          <p className={fieldStyles.sectionHint}>
+            Controls how nested toggles render on the back of a card.{' '}
+            <em>Open nested toggles</em> shows their contents expanded;{' '}
+            <em>Close nested toggles</em> keeps them collapsed so you can reveal
+            them one at a time while reviewing.
+          </p>
           <TemplateSelect
             values={[
               { label: 'Open nested toggles', value: 'open_toggle' },


### PR DESCRIPTION
## Summary
Users reported not understanding the toggle options, particularly the **Toggle Mode** select which had no helper text at all.

Two additions on `CardOptionsForm.tsx`, using the existing `.sectionHint` style:

1. **Intro paragraph** above the Toggle Mode section:
   > **How toggles become cards:** each toggle's header is the front of a card, and its contents become the back. A toggle inside a toggle (nested toggle) becomes its own card using the rules below.

2. **Helper text** on the Toggle Mode select (previously empty):
   > Controls how nested toggles render on the back of a card. *Open nested toggles* shows their contents expanded; *Close nested toggles* keeps them collapsed so you can reveal them one at a time while reviewing.

No behavioural changes; copy-only.

## Flagged, not fixed
- The checkbox options below (cherry 🍒, avocado 🥑, max-one-toggle-per-card) are rendered from server-side copy in `supportedOptions.ts`. The `max-one-toggle-per-card` helper references "Use all toggle lists" which doesn't exist as a checkbox. Needs a server-side copy fix; out of scope for this web-only PR.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test --run` — 21 pass (no behaviour tests touched)
- [ ] Manual: open `/settings/card-options` → see intro + helper under Toggle Mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)