### PR TITLE
feat(uploads): warn before downloading an empty deck

### DIFF
--- a/src/pages/UploadPage/components/DownloadButton.tsx
+++ b/src/pages/UploadPage/components/DownloadButton.tsx
@@ -1,25 +1,28 @@
 import { useEffect, useRef } from 'react';
 import { getDownloadFileName } from '../../DownloadsPage/helpers/getDownloadFileName';
 import formStyles from './UploadForm/UploadForm.module.css';
+import sharedStyles from '../../../styles/shared.module.css';
 
 interface Props {
   downloadLink: string | null | undefined;
   deckName: string | undefined;
   uploading: boolean;
+  cardCount?: number | null;
 }
 
 function DownloadButton(props: Props) {
-  const { downloadLink, deckName, uploading } = props;
+  const { downloadLink, deckName, uploading, cardCount } = props;
   const isDownloadable = downloadLink && deckName;
   const downloadRef = useRef<HTMLAnchorElement>(null);
 
   const isReady = downloadLink && !uploading;
+  const isEmptyDeck = cardCount === 0;
 
   useEffect(() => {
-    if (isReady) {
+    if (isReady && !isEmptyDeck) {
       downloadRef.current?.click();
     }
-  }, [isReady, downloadRef]);
+  }, [isReady, isEmptyDeck, downloadRef]);
 
   if (!isDownloadable && !uploading) {
     return null;
@@ -27,6 +30,19 @@ function DownloadButton(props: Props) {
 
   return (
     <div className={formStyles.downloadWrapper}>
+      {isReady && isEmptyDeck && (
+        <div className={sharedStyles.alertDanger}>
+          <p>
+            <strong>Your deck was created but contains no cards.</strong>{' '}
+            Check that your Notion page uses toggle blocks, or adjust your
+            conversion rules and try again.
+          </p>
+          <p className={sharedStyles.smallDescription}>
+            You can still download the empty deck below if you want to inspect
+            it.
+          </p>
+        </div>
+      )}
       <button
         type="button"
         className={`${formStyles.downloadButton} ${
@@ -40,7 +56,11 @@ function DownloadButton(props: Props) {
         }}
         disabled={!isDownloadable}
       >
-        {uploading ? 'Converting...' : 'Download'}
+        {uploading
+          ? 'Converting...'
+          : isEmptyDeck
+            ? 'Download empty deck'
+            : 'Download'}
       </button>
       {downloadLink && (
         <a

--- a/src/pages/UploadPage/components/DownloadButton.tsx
+++ b/src/pages/UploadPage/components/DownloadButton.tsx
@@ -10,6 +10,12 @@ interface Props {
   cardCount?: number | null;
 }
 
+function getButtonLabel(uploading: boolean, isEmptyDeck: boolean): string {
+  if (uploading) return 'Converting...';
+  if (isEmptyDeck) return 'Download empty deck';
+  return 'Download';
+}
+
 function DownloadButton(props: Props) {
   const { downloadLink, deckName, uploading, cardCount } = props;
   const isDownloadable = downloadLink && deckName;
@@ -56,11 +62,7 @@ function DownloadButton(props: Props) {
         }}
         disabled={!isDownloadable}
       >
-        {uploading
-          ? 'Converting...'
-          : isEmptyDeck
-            ? 'Download empty deck'
-            : 'Download'}
+        {getButtonLabel(uploading, isEmptyDeck)}
       </button>
       {downloadLink && (
         <a

--- a/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -16,6 +16,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const [uploading, setUploading] = useState(false);
   const [downloadLink, setDownloadLink] = useState<null | string>('');
   const [deckName, setDeckName] = useState('');
+  const [cardCount, setCardCount] = useState<number | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const convertRef = useRef<HTMLButtonElement>(null);
 
@@ -60,6 +61,12 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
       const fallback =
         contentType === 'application/zip' ? 'Your Decks.zip' : 'Your deck.apkg';
       setDeckName(fileNameHeader ?? fallback);
+      const cardCountHeader = request.headers.get('X-Card-Count');
+      const parsedCardCount =
+        cardCountHeader !== null ? Number.parseInt(cardCountHeader, 10) : null;
+      setCardCount(
+        Number.isFinite(parsedCardCount as number) ? (parsedCardCount as number) : null
+      );
       const blob = await request.blob();
       setDownloadLink(window.URL.createObjectURL(blob));
       setUploading(false);
@@ -104,6 +111,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
         downloadLink={downloadLink}
         deckName={deckName}
         uploading={uploading}
+        cardCount={cardCount}
       />
       <button
         aria-label="Upload file"

--- a/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -62,10 +62,11 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
         contentType === 'application/zip' ? 'Your Decks.zip' : 'Your deck.apkg';
       setDeckName(fileNameHeader ?? fallback);
       const cardCountHeader = request.headers.get('X-Card-Count');
-      const parsedCardCount =
-        cardCountHeader !== null ? Number.parseInt(cardCountHeader, 10) : null;
+      const parsedCardCount = cardCountHeader
+        ? Number.parseInt(cardCountHeader, 10)
+        : null;
       setCardCount(
-        Number.isFinite(parsedCardCount as number) ? (parsedCardCount as number) : null
+        Number.isFinite(parsedCardCount) ? parsedCardCount : null
       );
       const blob = await request.blob();
       setDownloadLink(window.URL.createObjectURL(blob));


### PR DESCRIPTION
## Summary
When the server conversion produces zero cards, suppress the auto-download and show a red banner explaining what's going on. The user can still download manually if they want to inspect the empty deck.

**Requires server PR [2anki/server#1983](https://github.com/2anki/server/pull/1983) to be merged first** — that's the one emitting the `X-Card-Count` response header. Without it, this PR is a no-op (header missing → cardCount stays null → existing behaviour).

## Changes
- `UploadForm.tsx` reads `X-Card-Count` from the response headers and passes the number into `DownloadButton`.
- `DownloadButton.tsx`:
  - If `cardCount === 0`: the `useEffect` auto-click no longer fires; button label flips to "Download empty deck"; a red banner explains the likely cause.
  - If `cardCount` is any other value (including `null` from legacy servers): unchanged — auto-downloads as before.

## Copy
> **Your deck was created but contains no cards.** Check that your Notion page uses toggle blocks, or adjust your conversion rules and try again.
>
> *You can still download the empty deck below if you want to inspect it.*

## Out of scope
- Async/Claude job download path (`FinishedJobs`, `ListJobs`). Needs a schema migration on the server to store card count per job; will land in a follow-up.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test --run` — 21 pass
- [ ] Manual: upload a file that yields zero cards → banner appears, download does NOT auto-fire, button label is "Download empty deck" and still works on click.
- [ ] Manual: upload a normal file → auto-download fires as before.
- [ ] Manual: point at an older server (no `X-Card-Count` header) → unchanged behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)