### PR TITLE
feat(downloads): add Refresh button to the Downloads page

### DIFF
--- a/src/pages/DownloadsPage/DownloadsPage.module.css
+++ b/src/pages/DownloadsPage/DownloadsPage.module.css
@@ -6,6 +6,41 @@
 
 .header {
   margin-bottom: 2.5rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.headerCopy {
+  flex: 1;
+}
+
+.refreshButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.875rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: #4b5563;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+  align-self: center;
+}
+
+.refreshButton:hover {
+  background: #f9fafb;
+  color: #1f2937;
+}
+
+.refreshButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .title {

--- a/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Index from './components/ListJobs';
 
 import useUploads from './hooks/useUploads';
@@ -16,11 +17,24 @@ interface DownloadsPageProps {
 }
 
 export function DownloadsPage({ setError }: DownloadsPageProps) {
-  const { deleteUpload, loading, uploads, error } = useUploads(get2ankiApi());
+  const { deleteUpload, loading, uploads, error, refreshUploads } = useUploads(
+    get2ankiApi()
+  );
   const { jobs, deleteJob, restartJob, refreshJobs } = useJobs(
     get2ankiApi(),
     setError
   );
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await Promise.all([refreshJobs(), refreshUploads()]);
+    } finally {
+      setRefreshing(false);
+    }
+  };
   const activeJobs = jobs.filter((j) => !['done', 'failed', 'cancelled', 'interrupted'].includes(j.status));
   const doneJobs = jobs.filter((j) => j.status === 'done');
   const failedJobs = jobs.filter((j) => ['failed', 'cancelled', 'interrupted'].includes(j.status));
@@ -38,10 +52,22 @@ export function DownloadsPage({ setError }: DownloadsPageProps) {
   return (
     <div className={styles.page}>
       <div className={styles.header}>
-        <h1 className={styles.title}>Downloads</h1>
-        <p className={styles.subtitle}>
-          Track your conversions and download completed flashcard decks.
-        </p>
+        <div className={styles.headerCopy}>
+          <h1 className={styles.title}>Downloads</h1>
+          <p className={styles.subtitle}>
+            Track your conversions and download completed flashcard decks.
+          </p>
+        </div>
+        <button
+          type="button"
+          className={styles.refreshButton}
+          onClick={handleRefresh}
+          disabled={refreshing}
+          aria-label="Refresh downloads"
+        >
+          <i className="fa-solid fa-arrows-rotate" aria-hidden="true" />
+          {refreshing ? 'Refreshing…' : 'Refresh'}
+        </button>
       </div>
 
       <EmptyDownloadsSection hasActiveJobs={unfinishedJob} uploads={uploads} />

--- a/src/pages/DownloadsPage/hooks/useUploads.tsx
+++ b/src/pages/DownloadsPage/hooks/useUploads.tsx
@@ -8,6 +8,7 @@ interface UseUploads {
   loading: boolean;
   uploads: UserUpload[] | undefined;
   deleteUpload: (key: string) => Promise<void>;
+  refreshUploads: () => Promise<void>;
 }
 
 export default function useUploads(backend: Backend): UseUploads {
@@ -15,6 +16,22 @@ export default function useUploads(backend: Backend): UseUploads {
   const [error, setError] = useState<unknown>(null);
   const [loading, setLoading] = useState(true);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  const fetchUploads = async () => {
+    try {
+      return await backend.getUploads();
+    } catch (fetchError) {
+      setError(fetchError);
+    }
+    return undefined;
+  };
+
+  const refreshUploads = async () => {
+    const data = await fetchUploads();
+    if (data) {
+      setUploads(data);
+    }
+  };
   const deleteUpload = async (key: string) => {
     if (isDeleting) {
       return;
@@ -31,15 +48,6 @@ export default function useUploads(backend: Backend): UseUploads {
   };
 
   useEffect(() => {
-    async function fetchUploads() {
-      try {
-        return await backend.getUploads();
-      } catch (fetchError) {
-        setError(fetchError);
-      }
-      return undefined;
-    }
-
     fetchUploads().then((data) => {
       setUploads(data);
       setLoading(false);
@@ -54,6 +62,7 @@ export default function useUploads(backend: Backend): UseUploads {
     }, 10000);
 
     return () => clearInterval(intervalId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backend]);
 
   return {
@@ -61,5 +70,6 @@ export default function useUploads(backend: Backend): UseUploads {
     loading,
     uploads,
     error,
+    refreshUploads,
   };
 }


### PR DESCRIPTION
## Summary
The Downloads page (`/uploads`) polls jobs and uploads every 3–10s in the background, but users have reported that they can't tell when new state has arrived. Add an explicit page-level **Refresh** button in the header so a user can force an immediate refresh without a full browser reload.

## Changes
- `useUploads` now exposes a `refreshUploads()` function alongside its existing polling loop.
- `DownloadsPage` wires `refreshJobs()` + `refreshUploads()` behind a single "Refresh" button with a rotating-arrows icon.
- While a refresh is in flight the button disables and its label flips to "Refreshing…".
- Header is now a flex row so the button sits alongside the title.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test --run` — 30 pass
- [ ] Manual: visit `/uploads` → see the Refresh button on the right of the header; clicking it refreshes jobs + uploads; disables during the in-flight request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)