### PR TITLE
refactor(navbar): reorder items, add profile dropdown, gate Favorites

### DIFF
--- a/src/components/NavigationBar/components/RightSide.tsx
+++ b/src/components/NavigationBar/components/RightSide.tsx
@@ -12,12 +12,6 @@ export function RightSide({ path }: Readonly<RightSideProps>) {
       <NavbarItem href="/upload" path={path}>
         {getVisibleText('navigation.upload')}
       </NavbarItem>
-      <NavbarItem href="/documentation" path={path}>
-        {getVisibleText('navigation.documentation')}
-      </NavbarItem>
-      <NavbarItem href="/contact" path={path}>
-        {getVisibleText('navigation.contact')}
-      </NavbarItem>
       <NavbarItem path="pricing" href="/pricing">
         {getVisibleText('navigation.pricing')}
       </NavbarItem>

--- a/src/components/NavigationBar/helpers/useNavbarEnd.tsx
+++ b/src/components/NavigationBar/helpers/useNavbarEnd.tsx
@@ -79,7 +79,6 @@ export default function useNavbarEnd(path: string, backend: Backend) {
             onKeyDown={(event) => {
               if (event.key === 'Escape') closeDropdown();
             }}
-            role="menu"
           >
             <NavbarItem href="/account" path={path}>
               Account

--- a/src/components/NavigationBar/helpers/useNavbarEnd.tsx
+++ b/src/components/NavigationBar/helpers/useNavbarEnd.tsx
@@ -1,14 +1,19 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { getVisibleText } from '../../../lib/text/getVisibleText';
 import Backend from '../../../lib/backend';
 import NavbarItem from '../NavbarItem';
 import { useUserLocals } from '../../../lib/hooks/useUserLocals';
+import { useFavoritesCount } from '../../../lib/hooks/useFavoritesCount';
 import styles from '../NavigationBar.module.css';
 
 export default function useNavbarEnd(path: string, backend: Backend) {
   const [isActive, setIsActive] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
   const onLogOut = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     event.preventDefault();
+    const confirmed = globalThis.confirm('Are you sure you want to log out?');
+    if (!confirmed) return;
     backend.logout();
   };
 
@@ -16,8 +21,24 @@ export default function useNavbarEnd(path: string, backend: Backend) {
   const isPaying = data?.locals?.patreon || data?.locals?.subscriber;
   const isLoggedIn = !!data?.user;
   const showKiLink = data?.features?.kiUI;
+  const favoritesCount = useFavoritesCount(isLoggedIn);
 
-  const toggleDropdown = () => setIsActive(!isActive);
+  const toggleDropdown = () => setIsActive((prev) => !prev);
+  const closeDropdown = () => setIsActive(false);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsActive(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isActive]);
 
   return (
     <div className={styles.navEnd}>
@@ -26,26 +47,24 @@ export default function useNavbarEnd(path: string, backend: Backend) {
           KI 🧪
         </NavbarItem>
       )}
-      {!isLoading && !isPaying && (
-        <NavbarItem href="/pricing" path={path}>
-          {getVisibleText('navigation.pricing')}
-        </NavbarItem>
-      )}
       <NavbarItem href="/upload" path={path}>
         {getVisibleText('navigation.upload')}
       </NavbarItem>
       <NavbarItem href="/uploads" path={path}>
         {getVisibleText('navigation.uploads')}
       </NavbarItem>
-      <NavbarItem href="/search" path={path}>
-        {getVisibleText('navigation.search')}
-      </NavbarItem>
+      {!isLoading && !isPaying && (
+        <NavbarItem href="/pricing" path={path}>
+          {getVisibleText('navigation.pricing')}
+        </NavbarItem>
+      )}
       {isLoggedIn && (
-        <div className={styles.dropdown} id="navbar-user-menu">
+        <div className={styles.dropdown} id="navbar-user-menu" ref={dropdownRef}>
           <button
             onClick={toggleDropdown}
             className={styles.dropdownToggle}
             aria-haspopup="true"
+            aria-expanded={isActive}
             aria-controls="navbar-user-menu"
             aria-label="Account menu"
             type="button"
@@ -56,15 +75,28 @@ export default function useNavbarEnd(path: string, backend: Backend) {
             className={`${styles.dropdownMenu} ${
               isActive ? styles.dropdownMenuActive : ''
             }`}
+            onClick={closeDropdown}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') closeDropdown();
+            }}
+            role="menu"
           >
             <NavbarItem href="/account" path={path}>
               Account
             </NavbarItem>
-            <NavbarItem href="/favorites" path={path}>
-              {getVisibleText('navigation.favorites')}
+            <NavbarItem href="/search" path={path}>
+              {getVisibleText('navigation.search')}
             </NavbarItem>
+            {favoritesCount > 0 && (
+              <NavbarItem href="/favorites" path={path}>
+                {getVisibleText('navigation.favorites')}
+              </NavbarItem>
+            )}
             <NavbarItem href="/documentation" path={path}>
               {getVisibleText('navigation.documentation')}
+            </NavbarItem>
+            <NavbarItem href="/contact" path={path}>
+              {getVisibleText('navigation.contact')}
             </NavbarItem>
             <hr className={styles.dropdownDivider} />
             <a

--- a/src/components/NavigationBar/helpers/useNavbarEnd.tsx
+++ b/src/components/NavigationBar/helpers/useNavbarEnd.tsx
@@ -36,8 +36,15 @@ export default function useNavbarEnd(path: string, backend: Backend) {
         setIsActive(false);
       }
     };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsActive(false);
+    };
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
   }, [isActive]);
 
   return (
@@ -75,26 +82,30 @@ export default function useNavbarEnd(path: string, backend: Backend) {
             className={`${styles.dropdownMenu} ${
               isActive ? styles.dropdownMenuActive : ''
             }`}
-            onClick={closeDropdown}
-            onKeyDown={(event) => {
-              if (event.key === 'Escape') closeDropdown();
-            }}
           >
-            <NavbarItem href="/account" path={path}>
+            <NavbarItem href="/account" path={path} onClick={closeDropdown}>
               Account
             </NavbarItem>
-            <NavbarItem href="/search" path={path}>
+            <NavbarItem href="/search" path={path} onClick={closeDropdown}>
               {getVisibleText('navigation.search')}
             </NavbarItem>
             {favoritesCount > 0 && (
-              <NavbarItem href="/favorites" path={path}>
+              <NavbarItem
+                href="/favorites"
+                path={path}
+                onClick={closeDropdown}
+              >
                 {getVisibleText('navigation.favorites')}
               </NavbarItem>
             )}
-            <NavbarItem href="/documentation" path={path}>
+            <NavbarItem
+              href="/documentation"
+              path={path}
+              onClick={closeDropdown}
+            >
               {getVisibleText('navigation.documentation')}
             </NavbarItem>
-            <NavbarItem href="/contact" path={path}>
+            <NavbarItem href="/contact" path={path} onClick={closeDropdown}>
               {getVisibleText('navigation.contact')}
             </NavbarItem>
             <hr className={styles.dropdownDivider} />

--- a/src/lib/hooks/useFavoritesCount.ts
+++ b/src/lib/hooks/useFavoritesCount.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { get2ankiApi } from '../backend/get2ankiApi';
+
+export function useFavoritesCount(enabled: boolean): number {
+  const { data } = useQuery({
+    queryKey: ['favoritesCount'],
+    queryFn: async () => {
+      const favorites = await get2ankiApi().getFavorites();
+      return favorites.length;
+    },
+    enabled,
+    staleTime: 60_000,
+  });
+
+  return data ?? 0;
+}


### PR DESCRIPTION
## Summary
UX audit said the navbar was too busy. Tighten the top bar to the essentials per state, move the rest behind the profile dropdown, and gate Favorites so it only shows up once a user has any.

### Top bar
| State | Before | After |
| --- | --- | --- |
| Logged-out | Upload, Documentation, Contact, Pricing, Login | **Upload, Pricing, Login** |
| Logged-in | (Pricing), Upload, Downloads, Search, ⋯ | **Upload, Downloads, Pricing (if !isPaying), ⋯** |

### Profile dropdown (⋯) when logged in
- Account
- Search *(moved from top bar)*
- Favorites — **now only shown when the user has ≥1 favorite** (new `useFavoritesCount` hook, 60s staleTime via react-query)
- Documentation
- Contact *(moved from top bar)*
- Log out *(now asks `confirm()` before signing out — covers UX #4's logout confirmation)*

Also: dropdown now closes on outside click and on Escape.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test --run` — 30 pass
- [ ] Manual logged-out: see Upload / Pricing / Login only.
- [ ] Manual logged-in without favorites: ⋯ menu excludes "Favorites".
- [ ] Manual logged-in with ≥1 favorite: ⋯ menu includes "Favorites".
- [ ] Manual: click Log out → confirm dialog; cancel stays signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)