### PR TITLE
fix(upload): surface clear upload-error copy instead of raw text

### DIFF
--- a/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -12,6 +12,67 @@ interface UploadFormProps {
   setErrorMessage: ErrorHandlerType;
 }
 
+const REJECTED_FALLBACK =
+  'The server rejected the upload. Please try again or contact support@2anki.net.';
+const NETWORK_FALLBACK =
+  "We couldn't upload your file. Please check your connection and try again.";
+
+async function extractErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = await response.clone().json();
+    if (
+      typeof body?.message === 'string' &&
+      body.message.trim().length > 0
+    ) {
+      return body.message;
+    }
+  } catch {
+    const text = await response.text().catch(() => '');
+    if (
+      text.length > 0 &&
+      text.length < 500 &&
+      !text.startsWith('<')
+    ) {
+      return text;
+    }
+  }
+  return REJECTED_FALLBACK;
+}
+
+function toFriendlyThrownError(error: unknown): Error {
+  const isNetworkError =
+    error instanceof TypeError ||
+    (error instanceof Error && /fetch|network/i.test(error.message));
+  if (isNetworkError) {
+    return new Error(NETWORK_FALLBACK);
+  }
+  return error as Error;
+}
+
+function buildFormData(form: HTMLFormElement): FormData {
+  const formData = new FormData(form);
+  for (const [key, value] of Object.entries(window.localStorage)) {
+    formData.append(key, value);
+  }
+  return formData;
+}
+
+function parseCardCountHeader(headers: Headers): number | null {
+  const cardCountHeader = headers.get('X-Card-Count');
+  if (!cardCountHeader) return null;
+  const parsed = Number.parseInt(cardCountHeader, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolveDeckName(headers: Headers): string {
+  const fileNameHeader = getHeadersFilename(headers);
+  const fallback =
+    headers.get('Content-Type') === 'application/zip'
+      ? 'Your Decks.zip'
+      : 'Your deck.apkg';
+  return fileNameHeader ?? fallback;
+}
+
 function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const [uploading, setUploading] = useState(false);
   const [downloadLink, setDownloadLink] = useState<null | string>('');
@@ -35,15 +96,11 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     event.preventDefault();
     setUploading(true);
     try {
-      const storedFields = Object.entries(window.localStorage);
-      const element = event.currentTarget as HTMLFormElement;
-      const formData = new FormData(element);
-      storedFields.forEach((sf) => formData.append(sf[0], sf[1]));
+      const formData = buildFormData(event.currentTarget as HTMLFormElement);
       const request = await window.fetch('/api/upload/file', {
         method: 'post',
         body: formData,
       });
-      const contentType = request.headers.get('Content-Type');
       if (request.redirected) {
         return handleRedirect(request);
       }
@@ -53,48 +110,18 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
         return true;
       }
       if (request.status !== 200) {
-        const fallback =
-          'The server rejected the upload. Please try again or contact support@2anki.net.';
-        let message = fallback;
-        try {
-          const body = await request.clone().json();
-          if (typeof body?.message === 'string' && body.message.trim().length > 0) {
-            message = body.message;
-          }
-        } catch {
-          const text = await request.text().catch(() => '');
-          if (text && text.length > 0 && text.length < 500 && !text.startsWith('<')) {
-            message = text;
-          }
-        }
+        const message = await extractErrorMessage(request);
         setDownloadLink(null);
         return setErrorMessage(new Error(message));
       }
-      const fileNameHeader = getHeadersFilename(request.headers);
-      const fallback =
-        contentType === 'application/zip' ? 'Your Decks.zip' : 'Your deck.apkg';
-      setDeckName(fileNameHeader ?? fallback);
-      const cardCountHeader = request.headers.get('X-Card-Count');
-      const parsedCardCount = cardCountHeader
-        ? Number.parseInt(cardCountHeader, 10)
-        : null;
-      setCardCount(
-        Number.isFinite(parsedCardCount) ? parsedCardCount : null
-      );
+      setDeckName(resolveDeckName(request.headers));
+      setCardCount(parseCardCountHeader(request.headers));
       const blob = await request.blob();
       setDownloadLink(window.URL.createObjectURL(blob));
       setUploading(false);
     } catch (error) {
       setDownloadLink(null);
-      const isNetworkError =
-        error instanceof TypeError ||
-        (error instanceof Error && /fetch|network/i.test(error.message));
-      const friendly = isNetworkError
-        ? new Error(
-            "We couldn't upload your file. Please check your connection and try again."
-          )
-        : (error as Error);
-      setErrorMessage(friendly);
+      setErrorMessage(toFriendlyThrownError(error));
       setUploading(false);
       return false;
     }

--- a/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -53,9 +53,22 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
         return true;
       }
       if (request.status !== 200) {
-        const text = await request.text();
+        const fallback =
+          'The server rejected the upload. Please try again or contact support@2anki.net.';
+        let message = fallback;
+        try {
+          const body = await request.clone().json();
+          if (typeof body?.message === 'string' && body.message.trim().length > 0) {
+            message = body.message;
+          }
+        } catch {
+          const text = await request.text().catch(() => '');
+          if (text && text.length > 0 && text.length < 500 && !text.startsWith('<')) {
+            message = text;
+          }
+        }
         setDownloadLink(null);
-        return setErrorMessage(text);
+        return setErrorMessage(new Error(message));
       }
       const fileNameHeader = getHeadersFilename(request.headers);
       const fallback =
@@ -73,7 +86,15 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
       setUploading(false);
     } catch (error) {
       setDownloadLink(null);
-      setErrorMessage(error as Error);
+      const isNetworkError =
+        error instanceof TypeError ||
+        (error instanceof Error && /fetch|network/i.test(error.message));
+      const friendly = isNetworkError
+        ? new Error(
+            "We couldn't upload your file. Please check your connection and try again."
+          )
+        : (error as Error);
+      setErrorMessage(friendly);
       setUploading(false);
       return false;
     }

--- a/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -51,7 +51,7 @@ function toFriendlyThrownError(error: unknown): Error {
 
 function buildFormData(form: HTMLFormElement): FormData {
   const formData = new FormData(form);
-  for (const [key, value] of Object.entries(window.localStorage)) {
+  for (const [key, value] of Object.entries(globalThis.localStorage)) {
     formData.append(key, value);
   }
   return formData;
@@ -97,7 +97,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     setUploading(true);
     try {
       const formData = buildFormData(event.currentTarget as HTMLFormElement);
-      const request = await window.fetch('/api/upload/file', {
+      const request = await globalThis.fetch('/api/upload/file', {
         method: 'post',
         body: formData,
       });
@@ -117,7 +117,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
       setDeckName(resolveDeckName(request.headers));
       setCardCount(parseCardCountHeader(request.headers));
       const blob = await request.blob();
-      setDownloadLink(window.URL.createObjectURL(blob));
+      setDownloadLink(globalThis.URL.createObjectURL(blob));
       setUploading(false);
     } catch (error) {
       setDownloadLink(null);


### PR DESCRIPTION
## Summary
Upload failures used to flow raw `request.text()` (sometimes HTML 5xx pages) straight into `setErrorMessage`, and network failures surfaced the bare `TypeError: Failed to fetch` string.

- **Non-200 responses**: read as JSON first — if the server sent `{ message: "..." }` (the shape the API standardised on in #852) we show that. Fall back to plain text only when it's short and not HTML; otherwise a generic actionable fallback with `support@2anki.net`.
- **Network failures** (`TypeError`, `/fetch|network/i`): show *"We couldn't upload your file. Please check your connection and try again."*

No behavioural change for successful uploads.

## Related UX 4 items already shipped elsewhere
- **Logout confirmation** → landed in the navbar cleanup PR #856 (`globalThis.confirm` before `backend.logout()`).
- **Subscription-change feedback** → landed earlier as inline success/error banners in `SubscriptionManagement` (see the subscription cancellation work).
- **Successful conversion state** → already the effective behaviour: `DownloadButton` renders with the deck name + an auto-triggered download once the server returns 200. PR #854 (zero-cards warning) handles the "created but empty" case explicitly.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test --run` — 30 pass
- [ ] Manual: disconnect network, try an upload → friendly connection copy.
- [ ] Manual: trigger a 400/500 response with JSON body → server `message` appears.
- [ ] Manual: trigger a 500 with HTML body → generic fallback (no HTML leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)