### PR TITLE
feat(pricing): gate Subscribe behind login and confirm on Account

### DIFF
--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -1,3 +1,4 @@
+import { useSearchParams } from 'react-router-dom';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import LoadingIndicator from '../../components/Loading';
 import { useSubscriptionStatus } from './hooks';
@@ -18,6 +19,14 @@ export default function AccountPage() {
     data?.locals
   );
   const notionData = useNotionData(get2ankiApi());
+  const [searchParams, setSearchParams] = useSearchParams();
+  const justSubscribed = searchParams.get('subscribed') === '1';
+
+  const dismissSubscribedBanner = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete('subscribed');
+    setSearchParams(next, { replace: true });
+  };
 
   if (isLoading) return <LoadingIndicator />;
 
@@ -36,6 +45,26 @@ export default function AccountPage() {
           Manage your profile, plan, and connected services.
         </p>
       </header>
+
+      {justSubscribed && (
+        <div
+          className={sharedStyles.alertSuccess}
+          role="status"
+          aria-live="polite"
+        >
+          <p>
+            <strong>Thanks for subscribing!</strong> Your plan is active —
+            you can see the details below.
+          </p>
+          <button
+            type="button"
+            className={sharedStyles.btnGhost}
+            onClick={dismissSubscribedBanner}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       <div className={styles.mainCard}>
         <UserProfile user={user} />

--- a/src/pages/PricingPage/PricingPage.tsx
+++ b/src/pages/PricingPage/PricingPage.tsx
@@ -11,7 +11,9 @@ interface PricingPageProps {
 export default function PricingPage({
   isLoggedIn,
 }: Readonly<PricingPageProps>) {
-  const subcribeLink = isLoggedIn ? getSubscribeLink() : '/login';
+  const subcribeLink = isLoggedIn
+    ? getSubscribeLink()
+    : '/login?redirect=/pricing';
   const lifetimeLink = getLifetimeLink();
 
   return (

--- a/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.ts
+++ b/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.ts
@@ -65,7 +65,10 @@ export const useSubscriptionStatus = () => {
         query.data.hasActiveSubscription ||
         (query.data.authenticated && timeoutReached)
       ) {
-        globalThis.location.href = '/search';
+        const destination = query.data.authenticated
+          ? '/account?subscribed=1'
+          : '/search';
+        globalThis.location.href = destination;
       }
     }
   }, [query.data, timeoutReached]);

--- a/src/styles/shared.module.css
+++ b/src/styles/shared.module.css
@@ -333,6 +333,20 @@
   font-size: var(--text-sm);
 }
 
+.alertSuccess {
+  background: var(--color-success-light);
+  border: 1px solid #a7f3d0;
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  color: #065f46;
+  font-size: var(--text-sm);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
 .alertWarning {
   background: var(--color-warning-light);
   border: 1px solid #fbbf24;


### PR DESCRIPTION
## Summary
Users paying while signed-out and then signing in with a different email end up without entitlement. The PricingPage already sent logged-out users to `/login`, but the post-login redirect defaulted to `/search`, so they never made it back to `/pricing` while authenticated.

Three small, self-contained changes — **no Stripe checkout, webhook, or schema changes**:

1. **PricingPage** — logged-out Subscribe link: `/login` → `/login?redirect=/pricing`. The server's `getRedirect` helper already whitelists `/pricing` and the login response echoes the redirect param back, so the user lands back on `/pricing` authenticated and can click Subscribe with the Stripe link active.

2. **SuccessfulCheckout** — when the polling detects the user is authenticated AND `hasActiveSubscription` (or the 90s timeout fires), route them to `/account?subscribed=1` instead of `/search`. Unauthenticated visitors still flow through the existing log-in-or-register path.

3. **AccountPage** — reads `?subscribed=1` and renders a dismissible success banner at the top ("Thanks for subscribing! Your plan is active — you can see the details below.") using a new `sharedStyles.alertSuccess` class. Dismiss removes the query param in place (`replace: true`) so reloads don't re-trigger it.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test --run` — 30 pass
- [ ] Manual, logged-out: click Subscribe on `/pricing` → land on `/login`; after login, return to `/pricing` with Subscribe enabled.
- [ ] Manual, logged-in post-Stripe-success: redirected from `/successful-checkout` to `/account?subscribed=1` → see green banner; Dismiss clears it without reload.
- [ ] Manual, anon post-Stripe: `/successful-checkout` still shows the existing "log in or register with same email" flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)