### PR TITLE
feat(preview): streaming Notion page preview with infinite scroll

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ const SuccessfulCheckoutPage = lazy(
 const DocsPage = lazy(() => import('./pages/DocsPage/DocsPage'));
 const CardOptionsPage = lazy(() => import('./pages/CardOptionsPage'));
 const RulesPage = lazy(() => import('./pages/RulesPage'));
+const PreviewPage = lazy(() => import('./pages/PreviewPage'));
 
 const queryClient = new QueryClient();
 
@@ -153,6 +154,12 @@ function AppContent({
             path="/rules/:id"
             element={requireAuth(
               <RulesPage setErrorMessage={setErrorMessage} />
+            )}
+          />
+          <Route
+            path="/preview/:id"
+            element={requireAuth(
+              <PreviewPage setError={setErrorMessage} />
             )}
           />
           <Route path="*" element={<NotFoundPage />} />

--- a/src/components/icons/EyeIcon.tsx
+++ b/src/components/icons/EyeIcon.tsx
@@ -3,7 +3,7 @@ interface IconProps {
   height: number;
 }
 
-export default function EyeIcon({ width, height }: IconProps) {
+export default function EyeIcon({ width, height }: Readonly<IconProps>) {
   return (
     <svg
       width={width}

--- a/src/components/icons/EyeIcon.tsx
+++ b/src/components/icons/EyeIcon.tsx
@@ -1,0 +1,24 @@
+interface IconProps {
+  width: number;
+  height: number;
+}
+
+export default function EyeIcon({ width, height }: IconProps) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+      <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  );
+}

--- a/src/lib/backend/getPreviewBatch.ts
+++ b/src/lib/backend/getPreviewBatch.ts
@@ -3,7 +3,10 @@ import { get } from './api';
 export interface PreviewBlock {
   id: string;
   type: string;
+  hasChildren: boolean;
+  canExpand: boolean;
   html: string;
+  summaryHtml?: string;
 }
 
 export interface PreviewBatch {

--- a/src/lib/backend/getPreviewBatch.ts
+++ b/src/lib/backend/getPreviewBatch.ts
@@ -1,0 +1,29 @@
+import { get } from './api';
+
+export interface PreviewBlock {
+  id: string;
+  type: string;
+  html: string;
+}
+
+export interface PreviewBatch {
+  blocks: PreviewBlock[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  pageTitle?: string;
+  pageUrl?: string | null;
+}
+
+export const getPreviewBatch = async (
+  pageId: string,
+  cursor?: string | null
+): Promise<PreviewBatch> => {
+  const params = new URLSearchParams();
+  if (cursor) params.set('cursor', cursor);
+  const qs = params.toString();
+  const url = `/api/notion/preview/${encodeURIComponent(pageId)}${
+    qs ? `?${qs}` : ''
+  }`;
+  const data = await get(url);
+  return data as PreviewBatch;
+};

--- a/src/lib/backend/getPreviewBatch.ts
+++ b/src/lib/backend/getPreviewBatch.ts
@@ -17,12 +17,18 @@ export interface PreviewBatch {
   pageUrl?: string | null;
 }
 
+interface PreviewBatchOptions {
+  parentKind?: 'page' | 'block';
+}
+
 export const getPreviewBatch = async (
   pageId: string,
-  cursor?: string | null
+  cursor?: string | null,
+  options: PreviewBatchOptions = {}
 ): Promise<PreviewBatch> => {
   const params = new URLSearchParams();
   if (cursor) params.set('cursor', cursor);
+  if (options.parentKind) params.set('parent', options.parentKind);
   const qs = params.toString();
   const url = `/api/notion/preview/${encodeURIComponent(pageId)}${
     qs ? `?${qs}` : ''

--- a/src/pages/PreviewPage/BlockNode.tsx
+++ b/src/pages/PreviewPage/BlockNode.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { PreviewBlock } from '../../lib/backend/getPreviewBatch';
+import { useBlockChildren } from './useBlockChildren';
+import styles from './PreviewPage.module.css';
+
+interface BlockNodeProps {
+  block: PreviewBlock;
+}
+
+export function BlockNode({ block }: Readonly<BlockNodeProps>) {
+  const [open, setOpen] = useState(false);
+
+  const { data, isLoading, error, refetch } = useBlockChildren(
+    block.id,
+    open && block.hasChildren
+  );
+
+  if (!block.canExpand) {
+    return (
+      <div
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: block.html }}
+      />
+    );
+  }
+
+  const children = data?.pages.flatMap((page) => page.blocks) ?? [];
+
+  return (
+    <details
+      className={styles.toggleBlock}
+      onToggle={(event) => setOpen((event.currentTarget as HTMLDetailsElement).open)}
+    >
+      <summary
+        className={styles.toggleSummary}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: block.summaryHtml ?? '' }}
+      />
+      {open && (
+        <div className={styles.toggleChildren}>
+          {!block.hasChildren && (
+            <p className={styles.muted}>
+              <em>This toggle has no children.</em>
+            </p>
+          )}
+          {isLoading && <p className={styles.muted}>Loading children…</p>}
+          {error && (
+            <p className={styles.muted}>
+              Couldn&apos;t load children.{' '}
+              <button
+                type="button"
+                className={styles.retryButton}
+                onClick={() => refetch()}
+              >
+                Try again
+              </button>
+            </p>
+          )}
+          {children.map((child) => (
+            <BlockNode key={child.id} block={child} />
+          ))}
+        </div>
+      )}
+    </details>
+  );
+}

--- a/src/pages/PreviewPage/PreviewPage.module.css
+++ b/src/pages/PreviewPage/PreviewPage.module.css
@@ -77,11 +77,48 @@
   border-radius: var(--radius-sm);
 }
 
-.preview :global(details em) {
-  display: block;
+.toggleBlock {
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+}
+
+.toggleSummary {
+  cursor: pointer;
+  font-weight: var(--font-medium);
+}
+
+.toggleSummary :global(h1),
+.toggleSummary :global(h2),
+.toggleSummary :global(h3),
+.toggleSummary :global(h4) {
+  display: inline;
+  margin: 0;
+}
+
+.toggleChildren {
+  margin-top: 0.5rem;
+  padding-left: 1rem;
+  border-left: 2px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.muted {
   color: var(--color-text-secondary);
   font-size: var(--text-xs);
-  margin-top: 0.25rem;
+  margin: 0;
+}
+
+.retryButton {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-primary);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: inherit;
 }
 
 .preview :global(figure) {

--- a/src/pages/PreviewPage/PreviewPage.module.css
+++ b/src/pages/PreviewPage/PreviewPage.module.css
@@ -1,0 +1,113 @@
+.backLink {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  padding: 0;
+  margin-bottom: 0.5rem;
+}
+
+.backLink:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+}
+
+.pageLink {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.pageLink a {
+  color: inherit;
+}
+
+.actionsRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.preview {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.5rem 2rem;
+  margin-top: 1.5rem;
+  line-height: 1.6;
+}
+
+.preview > :global(*):not(:last-child) {
+  margin-bottom: 0.75rem;
+}
+
+.preview :global(img) {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+}
+
+.preview :global(pre) {
+  background: var(--color-bg-secondary);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+}
+
+.preview :global(blockquote) {
+  border-left: 3px solid var(--color-border);
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--color-text-secondary);
+}
+
+.preview :global(aside) {
+  background: var(--color-bg-secondary);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  display: flex;
+  gap: 0.5rem;
+}
+
+.preview :global(details) {
+  background: var(--color-bg-secondary);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+}
+
+.preview :global(details em) {
+  display: block;
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  margin-top: 0.25rem;
+}
+
+.preview :global(figure) {
+  margin: 0;
+}
+
+.preview :global(figcaption) {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin-top: 0.25rem;
+}
+
+.sentinel {
+  height: 1px;
+}
+
+.loadingRow {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 0;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+}

--- a/src/pages/PreviewPage/PreviewPage.tsx
+++ b/src/pages/PreviewPage/PreviewPage.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import LoadingIndicator from '../../components/Loading';
+import { ErrorPresenter } from '../../components/errors/ErrorPresenter';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './PreviewPage.module.css';
+import { usePreviewStream } from './usePreviewStream';
+
+interface PreviewPageProps {
+  setError: ErrorHandlerType;
+}
+
+export default function PreviewPage({ setError }: Readonly<PreviewPageProps>) {
+  const { id } = useParams<{ id: string }>();
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const {
+    data,
+    isLoading,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    refetch,
+  } = usePreviewStream(id);
+
+  useEffect(() => {
+    if (error) setError(error);
+  }, [error, setError]);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    const node = sentinelRef.current;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (
+          entries[0]?.isIntersecting &&
+          hasNextPage &&
+          !isFetchingNextPage
+        ) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: '400px 0px' }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const firstPage = data?.pages?.[0];
+  const pageTitle = firstPage?.pageTitle ?? 'Loading…';
+  const pageUrl = firstPage?.pageUrl;
+
+  const blocks = useMemo(
+    () => data?.pages.flatMap((page) => page.blocks) ?? [],
+    [data]
+  );
+
+  if (!id) {
+    return (
+      <div className={sharedStyles.page}>
+        <p className={styles.empty}>Missing page id.</p>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className={sharedStyles.page}>
+        <header className={sharedStyles.pageHeader}>
+          <h1 className={sharedStyles.title}>Preview</h1>
+        </header>
+        <ErrorPresenter error={error} onRetry={() => refetch()} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={sharedStyles.page}>
+      <header className={sharedStyles.pageHeader}>
+        <Link to="/search" className={styles.backLink}>
+          ← Back to search
+        </Link>
+        <h1 className={sharedStyles.title} data-hj-suppress>
+          {pageTitle}
+        </h1>
+        {pageUrl && (
+          <p className={styles.pageLink}>
+            <a href={pageUrl} target="_blank" rel="noreferrer">
+              Open in Notion ↗
+            </a>
+          </p>
+        )}
+        <div className={styles.actionsRow}>
+          <Link
+            to={`/rules/${id}?returnTo=${encodeURIComponent(`/preview/${id}`)}`}
+            className={sharedStyles.btnSecondary}
+          >
+            Conversion rules
+          </Link>
+        </div>
+      </header>
+
+      {isLoading && !data ? (
+        <div className={styles.loadingRow}>
+          <LoadingIndicator />
+        </div>
+      ) : (
+        <article className={styles.preview}>
+          {blocks.length === 0 && (
+            <p className={styles.empty}>This page has no blocks to preview.</p>
+          )}
+          {blocks.map((block) => (
+            <div
+              key={block.id}
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: block.html }}
+            />
+          ))}
+        </article>
+      )}
+
+      <div ref={sentinelRef} className={styles.sentinel} aria-hidden="true" />
+
+      {isFetchingNextPage && (
+        <div className={styles.loadingRow}>Loading more…</div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/PreviewPage/PreviewPage.tsx
+++ b/src/pages/PreviewPage/PreviewPage.tsx
@@ -52,6 +52,8 @@ export default function PreviewPage({ setError }: Readonly<PreviewPageProps>) {
   const firstPage = data?.pages?.[0];
   const pageTitle = firstPage?.pageTitle ?? 'Loading…';
   const pageUrl = firstPage?.pageUrl;
+  const returnTo = encodeURIComponent(`/preview/${id}`);
+  const rulesHref = `/rules/${id}?returnTo=${returnTo}`;
 
   const blocks = useMemo(
     () => data?.pages.flatMap((page) => page.blocks) ?? [],
@@ -94,10 +96,7 @@ export default function PreviewPage({ setError }: Readonly<PreviewPageProps>) {
           </p>
         )}
         <div className={styles.actionsRow}>
-          <Link
-            to={`/rules/${id}?returnTo=${encodeURIComponent(`/preview/${id}`)}`}
-            className={sharedStyles.btnSecondary}
-          >
+          <Link to={rulesHref} className={sharedStyles.btnSecondary}>
             Conversion rules
           </Link>
         </div>

--- a/src/pages/PreviewPage/PreviewPage.tsx
+++ b/src/pages/PreviewPage/PreviewPage.tsx
@@ -6,6 +6,7 @@ import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessag
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './PreviewPage.module.css';
 import { usePreviewStream } from './usePreviewStream';
+import { BlockNode } from './BlockNode';
 
 interface PreviewPageProps {
   setError: ErrorHandlerType;
@@ -112,11 +113,7 @@ export default function PreviewPage({ setError }: Readonly<PreviewPageProps>) {
             <p className={styles.empty}>This page has no blocks to preview.</p>
           )}
           {blocks.map((block) => (
-            <div
-              key={block.id}
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: block.html }}
-            />
+            <BlockNode key={block.id} block={block} />
           ))}
         </article>
       )}

--- a/src/pages/PreviewPage/index.tsx
+++ b/src/pages/PreviewPage/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './PreviewPage';

--- a/src/pages/PreviewPage/useBlockChildren.ts
+++ b/src/pages/PreviewPage/useBlockChildren.ts
@@ -1,0 +1,18 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import {
+  getPreviewBatch,
+  PreviewBatch,
+} from '../../lib/backend/getPreviewBatch';
+
+export function useBlockChildren(blockId: string, enabled: boolean) {
+  return useInfiniteQuery<PreviewBatch, Error>({
+    queryKey: ['notionPreviewChildren', blockId],
+    enabled,
+    initialPageParam: null,
+    queryFn: ({ pageParam }) =>
+      getPreviewBatch(blockId, pageParam as string | null),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore && lastPage.nextCursor ? lastPage.nextCursor : undefined,
+    staleTime: 30_000,
+  });
+}

--- a/src/pages/PreviewPage/useBlockChildren.ts
+++ b/src/pages/PreviewPage/useBlockChildren.ts
@@ -10,7 +10,9 @@ export function useBlockChildren(blockId: string, enabled: boolean) {
     enabled,
     initialPageParam: null,
     queryFn: ({ pageParam }) =>
-      getPreviewBatch(blockId, pageParam as string | null),
+      getPreviewBatch(blockId, pageParam as string | null, {
+        parentKind: 'block',
+      }),
     getNextPageParam: (lastPage) =>
       lastPage.hasMore && lastPage.nextCursor ? lastPage.nextCursor : undefined,
     staleTime: 30_000,

--- a/src/pages/PreviewPage/usePreviewStream.ts
+++ b/src/pages/PreviewPage/usePreviewStream.ts
@@ -1,0 +1,17 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import {
+  getPreviewBatch,
+  PreviewBatch,
+} from '../../lib/backend/getPreviewBatch';
+
+export function usePreviewStream(pageId: string | undefined) {
+  return useInfiniteQuery<PreviewBatch, Error>({
+    queryKey: ['notionPreview', pageId],
+    enabled: !!pageId,
+    initialPageParam: null,
+    queryFn: ({ pageParam }) =>
+      getPreviewBatch(pageId as string, pageParam as string | null),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore && lastPage.nextCursor ? lastPage.nextCursor : undefined,
+  });
+}

--- a/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
+++ b/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import ObjectAction from '../actions/ObjectAction';
 import DotsHorizontal from '../../../../components/icons/DotsHorizontal';
@@ -8,6 +8,7 @@ import { OK } from '../../../../lib/backend/http';
 import { BlockIcon } from '../BlockIcon';
 import { ErrorHandlerType } from '../../../../components/errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
+import sharedStyles from '../../../../styles/shared.module.css';
 import styles from './SearchObjectEntry.module.css';
 
 interface Props {
@@ -73,6 +74,14 @@ function SearchObjectEntry(props: Readonly<Props>) {
           }}
         />
         <ObjectAction url={url} image="/icons/Notion_app_logo.png" />
+        {getType(type) !== 'database' && (
+          <Link
+            to={`/preview/${encodeURIComponent(id)}`}
+            className={sharedStyles.btnSmallPill}
+          >
+            Preview
+          </Link>
+        )}
         <button
           type="button"
           className={styles.rulesButton}

--- a/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
+++ b/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
@@ -3,12 +3,12 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import ObjectAction from '../actions/ObjectAction';
 import DotsHorizontal from '../../../../components/icons/DotsHorizontal';
+import EyeIcon from '../../../../components/icons/EyeIcon';
 import NotionObject from '../../../../lib/interfaces/NotionObject';
 import { OK } from '../../../../lib/backend/http';
 import { BlockIcon } from '../BlockIcon';
 import { ErrorHandlerType } from '../../../../components/errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
-import sharedStyles from '../../../../styles/shared.module.css';
 import styles from './SearchObjectEntry.module.css';
 
 interface Props {
@@ -77,9 +77,10 @@ function SearchObjectEntry(props: Readonly<Props>) {
         {getType(type) !== 'database' && (
           <Link
             to={`/preview/${encodeURIComponent(id)}`}
-            className={sharedStyles.btnSmallPill}
+            className={styles.rulesButton}
+            aria-label={`Preview ${title}`}
           >
-            Preview
+            <EyeIcon width={32} height={32} />
           </Link>
         )}
         <button

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,6 +1,17 @@
 import { test, expect } from '@playwright/test';
 
 test('homepage has correct title and hero text', async ({ page }) => {
+  await page.route('**/api/users/debug/locals**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        locals: { owner: null, patreon: false, subscriber: false },
+        features: {},
+      }),
+    })
+  );
+
   await page.goto('/');
 
   // Check title


### PR DESCRIPTION
## Summary
New `/preview/:id` page. Users see a Notion page as flashcard source material *before* converting — first batch appears in one fetch, more load as you scroll.

**Requires the paired server PR [2anki/server#1984](https://github.com/2anki/server/pull/1984) to land first** (adds the `/api/notion/preview/:id` endpoint).

## Flow
1. From `/search`, each page result now has a **Preview** pill (hidden for databases).
2. Clicking opens `/preview/<page-id>`.
3. First request arrives with page title + first 15 blocks — UI paints in one beat.
4. An `IntersectionObserver` on a sentinel 400px below the list fires `fetchNextPage` when scrolled near the bottom.
5. No cursor → stop paging.

## Files
- `src/lib/backend/getPreviewBatch.ts` — cursor-aware fetcher.
- `src/pages/PreviewPage/usePreviewStream.ts` — `useInfiniteQuery` with the server's `nextCursor` as `pageParam`.
- `src/pages/PreviewPage/PreviewPage.tsx` — page shell, server-HTML rendering via `dangerouslySetInnerHTML` (HTML comes straight from our server — no user-authored markup enters this path), error presenter with retry, "Open in Notion" + "Conversion rules" quick-links.
- `src/pages/PreviewPage/PreviewPage.module.css` — light prose styling for the rendered blocks (code/quote/callout/details/image).
- `src/pages/SearchPage/components/SearchObjectEntry/index.tsx` — Preview pill.
- `src/App.tsx` — lazy `/preview/:id` route gated by `RequireAuth`.

## Design notes
- Server returns HTML per block (see paired PR). Cheaper client, and doubles as a live check on the renderer.
- Toggles render as `<details>` with a placeholder — expansion is a conversion concern, not a preview one.
- Images hotlink Notion's signed URLs for the session; they expire in ~1h which is fine for a preview.
- Preview bypasses the block cache used by the conversion path (server side) so cursor boundaries are always fresh.

## Out of scope
- Nested toggle expansion on click (follow-up).
- "Preview as flashcards" view that applies the user's CardOptions (follow-up).
- Async/Claude path preview — Claude's output is deck-level not block-level.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test --run` — 30 pass
- [ ] Manual: visit `/search`, open Preview on a page with ≥30 blocks → first batch paints immediately, second batch loads as you scroll.
- [ ] Manual: Preview button hidden on database rows.
- [ ] Manual: unknown id → error banner with Retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)