### PR TITLE
refactor(navbar): move Account next to Log Out

### DIFF
--- a/src/components/NavigationBar/helpers/useNavbarEnd.tsx
+++ b/src/components/NavigationBar/helpers/useNavbarEnd.tsx
@@ -83,9 +83,6 @@ export default function useNavbarEnd(path: string, backend: Backend) {
               isActive ? styles.dropdownMenuActive : ''
             }`}
           >
-            <NavbarItem href="/account" path={path} onClick={closeDropdown}>
-              Account
-            </NavbarItem>
             <NavbarItem href="/search" path={path} onClick={closeDropdown}>
               {getVisibleText('navigation.search')}
             </NavbarItem>
@@ -109,6 +106,9 @@ export default function useNavbarEnd(path: string, backend: Backend) {
               {getVisibleText('navigation.contact')}
             </NavbarItem>
             <hr className={styles.dropdownDivider} />
+            <NavbarItem href="/account" path={path} onClick={closeDropdown}>
+              Account
+            </NavbarItem>
             <a
               className={styles.dropdownItem}
               href="/users/logout"


### PR DESCRIPTION
## Summary
- Moves **Account** from the top of the dropdown to just above **Log Out**, below the divider.
- Account is an identity/session action rather than a navigation target, so it reads better next to Log Out.

## New order
Search → Favorites (if any) → Documentation → Contact → — → Account → Log Out

## Test plan
- [ ] Visit any page while logged in, open the ⋯ dropdown, confirm order matches above.
- [ ] Clicking Account navigates to `/account` and closes the dropdown.
- [ ] Clicking Log Out still prompts and signs the user out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)