### PR TITLE
refactor(navbar): promote Search between Upload and Downloads

### DIFF
--- a/src/components/NavigationBar/helpers/useNavbarEnd.tsx
+++ b/src/components/NavigationBar/helpers/useNavbarEnd.tsx
@@ -57,6 +57,11 @@ export default function useNavbarEnd(path: string, backend: Backend) {
       <NavbarItem href="/upload" path={path}>
         {getVisibleText('navigation.upload')}
       </NavbarItem>
+      {isLoggedIn && (
+        <NavbarItem href="/search" path={path}>
+          {getVisibleText('navigation.search')}
+        </NavbarItem>
+      )}
       <NavbarItem href="/uploads" path={path}>
         {getVisibleText('navigation.uploads')}
       </NavbarItem>
@@ -83,9 +88,6 @@ export default function useNavbarEnd(path: string, backend: Backend) {
               isActive ? styles.dropdownMenuActive : ''
             }`}
           >
-            <NavbarItem href="/search" path={path} onClick={closeDropdown}>
-              {getVisibleText('navigation.search')}
-            </NavbarItem>
             {favoritesCount > 0 && (
               <NavbarItem
                 href="/favorites"


### PR DESCRIPTION
## Summary
- Moves **Search** out of the ⋯ dropdown and into the top-level navbar between **Upload** and **Downloads**.
- Only renders when logged in — anon users would just be redirected to /login anyway.

## Test plan
- [ ] Logged in: Search is visible between Upload and Downloads, click takes you to /search.
- [ ] Logged in: Search no longer appears in the ⋯ dropdown.
- [ ] Logged out: Search does not appear in the navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)