### PR TITLE
fix(loading): stop loader from inflating layout to 100vh

### DIFF
--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -3,7 +3,6 @@
   justify-content: center;
   align-items: center;
   font-size: var(--text-3xl);
-  height: 100vh;
-  width: 60vw;
-  margin: 0 auto;
+  min-height: 50vh;
+  width: 100%;
 }

--- a/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -45,10 +45,6 @@ export function DownloadsPage({ setError }: DownloadsPageProps) {
     return null;
   }
 
-  if (loading) {
-    return <LoadingIndicator />;
-  }
-
   return (
     <div className={styles.page}>
       <div className={styles.header}>
@@ -62,7 +58,7 @@ export function DownloadsPage({ setError }: DownloadsPageProps) {
           type="button"
           className={styles.refreshButton}
           onClick={handleRefresh}
-          disabled={refreshing}
+          disabled={refreshing || loading}
           aria-label="Refresh downloads"
         >
           <i className="fa-solid fa-arrows-rotate" aria-hidden="true" />
@@ -70,32 +66,46 @@ export function DownloadsPage({ setError }: DownloadsPageProps) {
         </button>
       </div>
 
-      <EmptyDownloadsSection hasActiveJobs={unfinishedJob} uploads={uploads} />
-
-      {unfinishedJob && (
-        <div className={styles.section}>
-          <UnfinishedJobsInfo />
-          <Index
-            restartJob={restartJob}
-            jobs={activeJobs}
-            deleteJob={(id) => deleteJob(id)}
-            refreshJobs={refreshJobs}
+      {loading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <EmptyDownloadsSection
+            hasActiveJobs={unfinishedJob}
+            uploads={uploads}
           />
-        </div>
-      )}
 
-      {failedJobs.length > 0 && (
-        <div className={styles.section}>
-          <Index
-            restartJob={restartJob}
-            jobs={failedJobs}
-            deleteJob={(id) => deleteJob(id)}
-            refreshJobs={refreshJobs}
+          {unfinishedJob && (
+            <div className={styles.section}>
+              <UnfinishedJobsInfo />
+              <Index
+                restartJob={restartJob}
+                jobs={activeJobs}
+                deleteJob={(id) => deleteJob(id)}
+                refreshJobs={refreshJobs}
+              />
+            </div>
+          )}
+
+          {failedJobs.length > 0 && (
+            <div className={styles.section}>
+              <Index
+                restartJob={restartJob}
+                jobs={failedJobs}
+                deleteJob={(id) => deleteJob(id)}
+                refreshJobs={refreshJobs}
+              />
+            </div>
+          )}
+
+          <FinishedJobs
+            uploads={uploads}
+            deleteUpload={deleteUpload}
+            doneJobs={doneJobs}
+            deleteJob={deleteJob}
           />
-        </div>
+        </>
       )}
-
-      <FinishedJobs uploads={uploads} deleteUpload={deleteUpload} doneJobs={doneJobs} deleteJob={deleteJob} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `LoadingIndicator` had \`height: 100vh; width: 60vw\` baked in, so any route using it (Suspense fallback, in-page loading) inflated the page to full viewport and caused visible jumps when real content took over.
- Switch to \`min-height: 50vh; width: 100%\` — still a centered block, but doesn't push layout past the actual content.
- `DownloadsPage` now keeps its header mounted while uploads/jobs load, matching `SearchPage` and preventing the header pop-in when navigating from /upload → /uploads.

## Test plan
- [ ] Navigate /upload → /search → /uploads → /upload repeatedly; the page header and navbar should stay put, no vertical jump.
- [ ] Initial app load (Suspense fallback) still shows the centered spinner.
- [ ] `/account`, `/favorites`, `/successful-checkout`, `/preview/:id` still show a reasonably-sized loader (not pinned to the top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)