### PR TITLE
refactor(route): rename /uploads to /downloads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,10 +86,14 @@ function AppContent({
             )}
           />
           <Route
-            path="/uploads"
+            path="/downloads"
             element={requireAuth(
               <DownloadsPage setError={setErrorMessage} />
             )}
+          />
+          <Route
+            path="/uploads"
+            element={<Navigate to="/downloads" replace />}
           />
           <Route
             path="/upload"

--- a/src/components/NavigationBar/helpers/useNavbarEnd.tsx
+++ b/src/components/NavigationBar/helpers/useNavbarEnd.tsx
@@ -62,7 +62,7 @@ export default function useNavbarEnd(path: string, backend: Backend) {
           {getVisibleText('navigation.search')}
         </NavbarItem>
       )}
-      <NavbarItem href="/uploads" path={path}>
+      <NavbarItem href="/downloads" path={path}>
         {getVisibleText('navigation.uploads')}
       </NavbarItem>
       {!isLoading && !isPaying && (

--- a/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
+++ b/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
@@ -56,7 +56,7 @@ function SearchObjectEntry(props: Readonly<Props>) {
       .convert(id, getType(type), title)
       .then((response) => {
         if (response.status === OK) {
-          window.location.href = '/uploads';
+          window.location.href = '/downloads';
         } else {
           setConverting(false);
           response.text().then(setError);

--- a/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -111,7 +111,7 @@ function UploadForm({
       }
       if (request.status === 202) {
         setUploading(false);
-        globalThis.location.href = '/uploads';
+        globalThis.location.href = '/downloads';
         return true;
       }
       if (request.status !== 200) {


### PR DESCRIPTION
## Summary
The page is titled \"Downloads\" (where converted decks live), but the URL was \`/uploads\` — users regularly confused it with the Upload page. Rename the route.

- \`/downloads\` is the new canonical route.
- \`/uploads\` is kept as a \`<Navigate replace>\` so old bookmarks and the server's current post-upload redirect (\`res.redirect('/uploads')\`) keep landing users in the right place.
- Navbar, Upload form post-202 redirect, and Search convert action all point at \`/downloads\`.

Pair with the server PR (coming next) that flips \`res.redirect('/uploads')\` → \`/downloads\`.

## Test plan
- [ ] Navigate via navbar: \"Downloads\" goes to \`/downloads\` and renders the same page.
- [ ] Visit \`/uploads\` directly: replaced by \`/downloads\` (history entry is clean).
- [ ] Upload a file: on success, browser lands on \`/downloads\`.
- [ ] In Search, click the Anki icon: after the redirect, URL is \`/downloads\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)