### PR TITLE
refactor(route): rename /search to /notion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,10 +104,14 @@ function AppContent({
             element={<RegisterPage setErrorMessage={setErrorMessage} />}
           />
           <Route
-            path="/search"
+            path="/notion"
             element={requireAuth(
               <SearchPage setError={setErrorMessage} />
             )}
+          />
+          <Route
+            path="/search"
+            element={<Navigate to="/notion" replace />}
           />
           <Route path="/login" element={<LoginPage />} />
           <Route

--- a/src/components/NavigationBar/helpers/useNavbarEnd.tsx
+++ b/src/components/NavigationBar/helpers/useNavbarEnd.tsx
@@ -58,7 +58,7 @@ export default function useNavbarEnd(path: string, backend: Backend) {
         {getVisibleText('navigation.upload')}
       </NavbarItem>
       {isLoggedIn && (
-        <NavbarItem href="/search" path={path}>
+        <NavbarItem href="/notion" path={path}>
           {getVisibleText('navigation.search')}
         </NavbarItem>
       )}

--- a/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
+++ b/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
@@ -19,7 +19,7 @@ export function EmptyDownloadsSection({ hasActiveJobs, uploads }: Prop) {
         <p className={styles.emptyDescription}>
           Convert a Notion page or upload a file to get started.
         </p>
-        <Link to="/search" className={styles.emptyLink}>
+        <Link to="/notion" className={styles.emptyLink}>
           Get started
         </Link>
       </div>

--- a/src/pages/PreviewPage/PreviewPage.tsx
+++ b/src/pages/PreviewPage/PreviewPage.tsx
@@ -82,8 +82,8 @@ export default function PreviewPage({ setError }: Readonly<PreviewPageProps>) {
   return (
     <div className={sharedStyles.page}>
       <header className={sharedStyles.pageHeader}>
-        <Link to="/search" className={styles.backLink}>
-          ← Back to search
+        <Link to="/notion" className={styles.backLink}>
+          ← Back to Notion search
         </Link>
         <h1 className={sharedStyles.title} data-hj-suppress>
           {pageTitle}

--- a/src/pages/RulesPage/RulesPage.tsx
+++ b/src/pages/RulesPage/RulesPage.tsx
@@ -65,7 +65,7 @@ export default function RulesPage({ setErrorMessage }: Readonly<Props>) {
   const headingTitle = titleParam ?? 'Conversion rules';
   const parent = titleParam ?? 'this page';
   const type = params.get('type');
-  const returnTo = params.get('returnTo') ?? '/search';
+  const returnTo = params.get('returnTo') ?? '/notion';
 
   const [rules, setRules] = useState<NewRule>(defaultRules);
   const [isLoading, setIsLoading] = useState(true);

--- a/src/pages/SearchPage/components/SearchPresenter.tsx
+++ b/src/pages/SearchPage/components/SearchPresenter.tsx
@@ -38,7 +38,7 @@ export default function SearchPresenter(props: SearchPresenterProps) {
           inProgress={inProgress}
           onSearchQueryChanged={(s) => {
             navigate(
-              { pathname: '/search', search: s ? `?q=${encodeURIComponent(s)}` : '' },
+              { pathname: '/notion', search: s ? `?q=${encodeURIComponent(s)}` : '' },
               { replace: true }
             );
             setSearchQuery(s);

--- a/src/pages/SuccessfulCheckout/components/TimeoutWarning.tsx
+++ b/src/pages/SuccessfulCheckout/components/TimeoutWarning.tsx
@@ -12,7 +12,7 @@ export const TimeoutWarning = ({ show }: TimeoutWarningProps) => {
       <p>
         <strong>Note:</strong> We're still processing your subscription
         activation. If you're already logged in, you can try visiting the{' '}
-        <a href="/search">search page</a> directly, or refresh this page to
+        <a href="/notion">Notion page</a> directly, or refresh this page to
         check again.
       </p>
     </div>

--- a/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.ts
+++ b/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.ts
@@ -67,7 +67,7 @@ export const useSubscriptionStatus = () => {
       ) {
         const destination = query.data.authenticated
           ? '/account?subscribed=1'
-          : '/search';
+          : '/notion';
         globalThis.location.href = destination;
       }
     }


### PR DESCRIPTION
## Summary
The page is specifically the Notion workspace search — the URL now says what it does. Same playbook as the /uploads → /downloads rename: new canonical route, legacy \`<Navigate replace>\` so existing bookmarks and the server's post-OAuth redirect keep working.

- \`/notion\` is the new canonical route.
- \`/search\` is a \`<Navigate replace>\` to \`/notion\`.
- Navbar, PreviewPage \"Back\", DownloadsPage empty-state, RulesPage \`returnTo\` default, SearchPresenter URL sync, and SuccessfulCheckout timeout fallback all updated.

Pair with the server PR (next) that updates \`res.redirect('/search')\` call sites + the redirect whitelist.

## Test plan
- [ ] Navbar \"Search\" link goes to \`/notion\`, page renders.
- [ ] Visiting \`/search\` redirects to \`/notion\` (replace, clean history).
- [ ] From \`/notion\`, open a page preview, hit \"Back to Notion search\" → lands on \`/notion\`.
- [ ] From rules page opened without a \`returnTo\` param, the default Cancel lands on \`/notion\`.
- [ ] Post-subscription timeout warning link points to \`/notion\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)