### PR TITLE
feat(apkg-preview): paginated .apkg preview page + Downloads Preview pill

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ const DocsPage = lazy(() => import('./pages/DocsPage/DocsPage'));
 const CardOptionsPage = lazy(() => import('./pages/CardOptionsPage'));
 const RulesPage = lazy(() => import('./pages/RulesPage'));
 const PreviewPage = lazy(() => import('./pages/PreviewPage'));
+const PreviewApkgPage = lazy(() => import('./pages/PreviewApkgPage'));
 
 const queryClient = new QueryClient();
 
@@ -168,6 +169,12 @@ function AppContent({
             path="/preview/:id"
             element={requireAuth(
               <PreviewPage setError={setErrorMessage} />
+            )}
+          />
+          <Route
+            path="/preview/apkg/:key"
+            element={requireAuth(
+              <PreviewApkgPage setError={setErrorMessage} />
             )}
           />
           <Route path="*" element={<NotFoundPage />} />

--- a/src/components/icons/DownloadIcon.tsx
+++ b/src/components/icons/DownloadIcon.tsx
@@ -1,0 +1,23 @@
+interface IconProps {
+  width?: number;
+  height?: number;
+}
+
+export default function DownloadIcon({
+  width = 20,
+  height = 20,
+}: IconProps) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      fill="currentColor"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path d="M10.75 2.75a.75.75 0 00-1.5 0v8.614L6.295 8.235a.75.75 0 10-1.09 1.03l4.25 4.5a.75.75 0 001.09 0l4.25-4.5a.75.75 0 00-1.09-1.03l-2.955 3.129V2.75z" />
+      <path d="M3.5 12.75a.75.75 0 00-1.5 0v2.5A2.75 2.75 0 004.75 18h10.5A2.75 2.75 0 0018 15.25v-2.5a.75.75 0 00-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5z" />
+    </svg>
+  );
+}

--- a/src/lib/backend/getApkgPreview.ts
+++ b/src/lib/backend/getApkgPreview.ts
@@ -5,6 +5,7 @@ export interface ApkgPreviewCard {
   ord: number;
   templateName: string;
   deckName: string;
+  deckPath: string[];
   noteTypeName: string;
   css: string;
   front: string;
@@ -17,9 +18,16 @@ export interface ApkgPreviewBatch {
   total: number;
 }
 
+export interface ApkgDeckMeta {
+  id: number;
+  fullName: string;
+  path: string[];
+  cardCount: number;
+}
+
 export interface ApkgPreviewMeta {
   totalCards: number;
-  deckNames: string[];
+  decks: ApkgDeckMeta[];
 }
 
 export async function getApkgPreviewMeta(
@@ -32,11 +40,13 @@ export async function getApkgPreviewMeta(
 export async function getApkgPreviewBatch(
   key: string,
   cursor: number | null,
-  pageSize = 20
+  options: { pageSize?: number; deckId?: number | null } = {}
 ): Promise<ApkgPreviewBatch> {
+  const { pageSize = 20, deckId = null } = options;
   const params = new URLSearchParams();
   if (cursor) params.set('cursor', String(cursor));
   params.set('page_size', String(pageSize));
+  if (deckId != null) params.set('deck_id', String(deckId));
   const url = `/api/apkg/${encodeURIComponent(key)}/cards?${params.toString()}`;
   return (await get(url)) as ApkgPreviewBatch;
 }

--- a/src/lib/backend/getApkgPreview.ts
+++ b/src/lib/backend/getApkgPreview.ts
@@ -1,0 +1,42 @@
+import { get } from './api';
+
+export interface ApkgPreviewCard {
+  id: number;
+  ord: number;
+  templateName: string;
+  deckName: string;
+  noteTypeName: string;
+  css: string;
+  front: string;
+  back: string;
+}
+
+export interface ApkgPreviewBatch {
+  cards: ApkgPreviewCard[];
+  nextCursor: number | null;
+  total: number;
+}
+
+export interface ApkgPreviewMeta {
+  totalCards: number;
+  deckNames: string[];
+}
+
+export async function getApkgPreviewMeta(
+  key: string
+): Promise<ApkgPreviewMeta> {
+  const url = `/api/apkg/${encodeURIComponent(key)}/meta`;
+  return (await get(url)) as ApkgPreviewMeta;
+}
+
+export async function getApkgPreviewBatch(
+  key: string,
+  cursor: number | null,
+  pageSize = 20
+): Promise<ApkgPreviewBatch> {
+  const params = new URLSearchParams();
+  if (cursor) params.set('cursor', String(cursor));
+  params.set('page_size', String(pageSize));
+  const url = `/api/apkg/${encodeURIComponent(key)}/cards?${params.toString()}`;
+  return (await get(url)) as ApkgPreviewBatch;
+}

--- a/src/pages/DownloadsPage/DownloadsPage.module.css
+++ b/src/pages/DownloadsPage/DownloadsPage.module.css
@@ -163,6 +163,28 @@
   color: #1d4ed8;
 }
 
+.previewButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.875rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 9999px;
+  text-decoration: none;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.previewButton:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
 .deleteButton {
   display: inline-flex;
   align-items: center;

--- a/src/pages/DownloadsPage/DownloadsPage.module.css
+++ b/src/pages/DownloadsPage/DownloadsPage.module.css
@@ -185,6 +185,39 @@
   border-color: var(--color-text-secondary);
 }
 
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  padding: 0;
+  text-decoration: none;
+}
+
+.iconButton:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-secondary);
+  border-color: var(--color-border);
+}
+
+.iconButton:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.iconButtonDanger:hover {
+  color: #b91c1c;
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
 .deleteButton {
   display: inline-flex;
   align-items: center;

--- a/src/pages/DownloadsPage/components/FinishedJobs.tsx
+++ b/src/pages/DownloadsPage/components/FinishedJobs.tsx
@@ -5,6 +5,9 @@ import UserUpload from '../../../lib/interfaces/UserUpload';
 import { JobsId } from '../../../schemas/public/Jobs';
 import JobResponse from '../../../schemas/public/JobResponse';
 import { getDistance } from '../../../lib/getDistance';
+import DownloadIcon from '../../../components/icons/DownloadIcon';
+import EyeIcon from '../../../components/icons/EyeIcon';
+import TrashIcon from '../../../components/icons/TrashIcon';
 import styles from '../DownloadsPage.module.css';
 import sharedStyles from '../../../styles/shared.module.css';
 
@@ -76,18 +79,20 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
                       <button
                         type="button"
                         onClick={() => deleteJob(j.id)}
-                        className={styles.deleteButton}
+                        className={`${styles.iconButton} ${styles.iconButtonDanger}`}
+                        aria-label={`Delete ${j.title}`}
+                        title="Delete"
                       >
-                        <i className="fa-solid fa-trash" aria-hidden="true" />
-                        Delete
+                        <TrashIcon width={18} height={18} />
                       </button>
                     )}
                     <a
                       href={`/api/upload/jobs/${j.object_id}/download`}
-                      className={styles.downloadButton}
+                      className={styles.iconButton}
+                      aria-label={`Download ${j.title}`}
+                      title="Download"
                     >
-                      <i className="fa-solid fa-download" aria-hidden="true" />
-                      Download
+                      <DownloadIcon width={18} height={18} />
                     </a>
                   </div>
                 </td>
@@ -112,27 +117,30 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
                     <button
                       type="button"
                       onClick={() => handleDelete(u.key)}
-                      className={styles.deleteButton}
+                      className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                       disabled={deletingKey === u.key}
+                      aria-label={`Delete ${u.filename}`}
+                      title={deletingKey === u.key ? 'Deleting…' : 'Delete'}
                     >
-                      <i className="fa-solid fa-trash" aria-hidden="true" />
-                      {deletingKey === u.key ? 'Deleting…' : 'Delete'}
+                      <TrashIcon width={18} height={18} />
                     </button>
                     {APKG_PATTERN.test(u.key) && (
                       <Link
                         to={`/preview/apkg/${encodeURIComponent(u.key)}`}
-                        className={styles.previewButton}
+                        className={styles.iconButton}
+                        aria-label={`Preview ${u.filename}`}
+                        title="Preview"
                       >
-                        <i className="fa-solid fa-eye" aria-hidden="true" />
-                        Preview
+                        <EyeIcon width={18} height={18} />
                       </Link>
                     )}
                     <a
                       href={`/api/download/u/${u.key}`}
-                      className={styles.downloadButton}
+                      className={styles.iconButton}
+                      aria-label={`Download ${u.filename}`}
+                      title="Download"
                     >
-                      <i className="fa-solid fa-download" aria-hidden="true" />
-                      Download
+                      <DownloadIcon width={18} height={18} />
                     </a>
                   </div>
                 </td>

--- a/src/pages/DownloadsPage/components/FinishedJobs.tsx
+++ b/src/pages/DownloadsPage/components/FinishedJobs.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import UserUpload from '../../../lib/interfaces/UserUpload';
 import { JobsId } from '../../../schemas/public/Jobs';
@@ -6,6 +7,8 @@ import JobResponse from '../../../schemas/public/JobResponse';
 import { getDistance } from '../../../lib/getDistance';
 import styles from '../DownloadsPage.module.css';
 import sharedStyles from '../../../styles/shared.module.css';
+
+const APKG_PATTERN = /\.apkg$/i;
 
 interface Prop {
   readonly uploads: UserUpload[] | undefined;
@@ -112,6 +115,14 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
                     >
                       {deletingKey === u.key ? 'Deleting...' : 'Delete'}
                     </button>
+                    {APKG_PATTERN.test(u.key) && (
+                      <Link
+                        to={`/preview/apkg/${encodeURIComponent(u.key)}`}
+                        className={styles.previewButton}
+                      >
+                        Preview
+                      </Link>
+                    )}
                     <a
                       href={`/api/download/u/${u.key}`}
                       className={styles.downloadButton}

--- a/src/pages/DownloadsPage/components/FinishedJobs.tsx
+++ b/src/pages/DownloadsPage/components/FinishedJobs.tsx
@@ -78,6 +78,7 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
                         onClick={() => deleteJob(j.id)}
                         className={styles.deleteButton}
                       >
+                        <i className="fa-solid fa-trash" aria-hidden="true" />
                         Delete
                       </button>
                     )}
@@ -85,6 +86,7 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
                       href={`/api/upload/jobs/${j.object_id}/download`}
                       className={styles.downloadButton}
                     >
+                      <i className="fa-solid fa-download" aria-hidden="true" />
                       Download
                     </a>
                   </div>
@@ -113,13 +115,15 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
                       className={styles.deleteButton}
                       disabled={deletingKey === u.key}
                     >
-                      {deletingKey === u.key ? 'Deleting...' : 'Delete'}
+                      <i className="fa-solid fa-trash" aria-hidden="true" />
+                      {deletingKey === u.key ? 'Deleting…' : 'Delete'}
                     </button>
                     {APKG_PATTERN.test(u.key) && (
                       <Link
                         to={`/preview/apkg/${encodeURIComponent(u.key)}`}
                         className={styles.previewButton}
                       >
+                        <i className="fa-solid fa-eye" aria-hidden="true" />
                         Preview
                       </Link>
                     )}
@@ -127,6 +131,7 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
                       href={`/api/download/u/${u.key}`}
                       className={styles.downloadButton}
                     >
+                      <i className="fa-solid fa-download" aria-hidden="true" />
                       Download
                     </a>
                   </div>

--- a/src/pages/PreviewApkgPage/CardFrame.tsx
+++ b/src/pages/PreviewApkgPage/CardFrame.tsx
@@ -35,9 +35,20 @@ export function CardFrame({ card }: Readonly<CardFrameProps>) {
   return (
     <section className={styles.card}>
       <header className={styles.cardHeader}>
-        <div>
-          <span className={styles.cardDeck}>{card.deckName}</span>
-          <span className={styles.cardDot}>·</span>
+        <div className={styles.cardDeckPath}>
+          {card.deckPath.map((segment, idx) => (
+            <span key={`${segment}-${idx}`} className={styles.cardDeckSegment}>
+              {idx > 0 && (
+                <span className={styles.cardDeckSeparator} aria-hidden="true">
+                  ›
+                </span>
+              )}
+              {segment}
+            </span>
+          ))}
+          <span className={styles.cardDot} aria-hidden="true">
+            ·
+          </span>
           <span className={styles.cardTemplate}>{card.templateName}</span>
         </div>
         <button

--- a/src/pages/PreviewApkgPage/CardFrame.tsx
+++ b/src/pages/PreviewApkgPage/CardFrame.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react';
+import { ApkgPreviewCard } from '../../lib/backend/getApkgPreview';
+import styles from './PreviewApkgPage.module.css';
+
+interface CardFrameProps {
+  card: ApkgPreviewCard;
+}
+
+function buildSrcDoc(card: ApkgPreviewCard, side: 'front' | 'back'): string {
+  const html = side === 'front' ? card.front : card.back;
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<base target="_blank">
+<style>
+  html, body { margin: 0; padding: 1rem; background: #fff; color: #111; font-family: system-ui, sans-serif; }
+  img, video { max-width: 100%; height: auto; }
+${card.css}
+</style>
+</head>
+<body>
+<div class="card">${html}</div>
+</body>
+</html>`;
+}
+
+export function CardFrame({ card }: Readonly<CardFrameProps>) {
+  const [showBack, setShowBack] = useState(false);
+  const srcDoc = useMemo(
+    () => buildSrcDoc(card, showBack ? 'back' : 'front'),
+    [card, showBack]
+  );
+
+  return (
+    <section className={styles.card}>
+      <header className={styles.cardHeader}>
+        <div>
+          <span className={styles.cardDeck}>{card.deckName}</span>
+          <span className={styles.cardDot}>·</span>
+          <span className={styles.cardTemplate}>{card.templateName}</span>
+        </div>
+        <button
+          type="button"
+          className={styles.flipButton}
+          onClick={() => setShowBack((prev) => !prev)}
+          aria-pressed={showBack}
+        >
+          {showBack ? 'Show front' : 'Show back'}
+        </button>
+      </header>
+      <iframe
+        className={styles.cardFrame}
+        title={`${card.deckName} / ${card.templateName} (${
+          showBack ? 'back' : 'front'
+        })`}
+        sandbox="allow-same-origin"
+        srcDoc={srcDoc}
+      />
+    </section>
+  );
+}

--- a/src/pages/PreviewApkgPage/CardFrame.tsx
+++ b/src/pages/PreviewApkgPage/CardFrame.tsx
@@ -25,18 +25,27 @@ ${card.css}
 </html>`;
 }
 
+function resolveDeckSegments(card: ApkgPreviewCard): string[] {
+  if (Array.isArray(card.deckPath) && card.deckPath.length > 0) {
+    return card.deckPath;
+  }
+  if (card.deckName) return card.deckName.split('::');
+  return [];
+}
+
 export function CardFrame({ card }: Readonly<CardFrameProps>) {
   const [showBack, setShowBack] = useState(false);
   const srcDoc = useMemo(
     () => buildSrcDoc(card, showBack ? 'back' : 'front'),
     [card, showBack]
   );
+  const deckSegments = useMemo(() => resolveDeckSegments(card), [card]);
 
   return (
     <section className={styles.card}>
       <header className={styles.cardHeader}>
         <div className={styles.cardDeckPath}>
-          {card.deckPath.map((segment, idx) => (
+          {deckSegments.map((segment, idx) => (
             <span key={`${segment}-${idx}`} className={styles.cardDeckSegment}>
               {idx > 0 && (
                 <span className={styles.cardDeckSeparator} aria-hidden="true">

--- a/src/pages/PreviewApkgPage/PreviewApkgPage.module.css
+++ b/src/pages/PreviewApkgPage/PreviewApkgPage.module.css
@@ -1,0 +1,100 @@
+.backLink {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  padding: 0;
+  margin-bottom: 0.5rem;
+  display: inline-block;
+}
+
+.backLink:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+}
+
+.summary {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0 0 1.5rem;
+}
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  font-size: var(--text-sm);
+}
+
+.cardDeck {
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}
+
+.cardDot {
+  margin: 0 0.5rem;
+  color: var(--color-text-secondary);
+}
+
+.cardTemplate {
+  color: var(--color-text-secondary);
+}
+
+.flipButton {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.75rem;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: var(--text-xs);
+}
+
+.flipButton:hover {
+  background: var(--color-bg-primary);
+}
+
+.cardFrame {
+  border: 0;
+  width: 100%;
+  min-height: 160px;
+  height: 260px;
+  background: #fff;
+}
+
+.sentinel {
+  height: 1px;
+}
+
+.loadingRow {
+  display: flex;
+  justify-content: center;
+  padding: 1rem 0;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+}

--- a/src/pages/PreviewApkgPage/PreviewApkgPage.module.css
+++ b/src/pages/PreviewApkgPage/PreviewApkgPage.module.css
@@ -45,9 +45,24 @@
   font-size: var(--text-sm);
 }
 
-.cardDeck {
+.cardDeckPath {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.125rem;
   font-weight: var(--font-medium);
   color: var(--color-text-primary);
+}
+
+.cardDeckSegment {
+  display: inline-flex;
+  align-items: center;
+}
+
+.cardDeckSeparator {
+  margin: 0 0.375rem;
+  color: var(--color-text-secondary);
+  font-weight: var(--font-regular);
 }
 
 .cardDot {
@@ -57,6 +72,25 @@
 
 .cardTemplate {
   color: var(--color-text-secondary);
+  font-weight: var(--font-regular);
+}
+
+.deckFilter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.75rem 0 1.5rem;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.deckFilter select {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: inherit;
 }
 
 .flipButton {

--- a/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
+++ b/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
@@ -88,7 +88,7 @@ export default function PreviewApkgPage({
   const filteredTotal = stream.data?.pages[0]?.total;
   const totalAll = meta.data?.totalCards;
   const loadedCount = cards.length;
-  const decks = meta.data?.decks ?? [];
+  const decks = Array.isArray(meta.data?.decks) ? meta.data.decks : [];
   const selectedDeck = decks.find((d) => d.id === deckId) ?? null;
 
   return (

--- a/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
+++ b/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { ErrorPresenter } from '../../components/errors/ErrorPresenter';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
@@ -11,6 +11,11 @@ import {
 } from './useApkgPreviewStream';
 import { CardFrame } from './CardFrame';
 
+function indent(depth: number): string {
+  if (depth <= 0) return '';
+  return `${'\u00a0\u00a0'.repeat(depth)}↳ `;
+}
+
 interface PreviewApkgPageProps {
   setError: ErrorHandlerType;
 }
@@ -20,9 +25,10 @@ export default function PreviewApkgPage({
 }: Readonly<PreviewApkgPageProps>) {
   const { key } = useParams<{ key: string }>();
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const [deckId, setDeckId] = useState<number | null>(null);
 
   const meta = useApkgPreviewMeta(key);
-  const stream = useApkgPreviewStream(key);
+  const stream = useApkgPreviewStream(key, deckId);
 
   useEffect(() => {
     const firstError = stream.error ?? meta.error;
@@ -79,8 +85,11 @@ export default function PreviewApkgPage({
     );
   }
 
-  const total = meta.data?.totalCards ?? stream.data?.pages[0]?.total;
+  const filteredTotal = stream.data?.pages[0]?.total;
+  const totalAll = meta.data?.totalCards;
   const loadedCount = cards.length;
+  const decks = meta.data?.decks ?? [];
+  const selectedDeck = decks.find((d) => d.id === deckId) ?? null;
 
   return (
     <div className={sharedStyles.page}>
@@ -92,13 +101,41 @@ export default function PreviewApkgPage({
           Deck preview
         </h1>
         <p className={styles.summary}>
-          {meta.data?.deckNames.length
-            ? `${meta.data.deckNames.join(', ')} · `
-            : ''}
-          {total != null
-            ? `${loadedCount} of ${total} cards loaded`
-            : 'Loading…'}
+          {selectedDeck ? (
+            <>
+              {selectedDeck.fullName} · {loadedCount} of{' '}
+              {filteredTotal ?? selectedDeck.cardCount} cards loaded
+            </>
+          ) : (
+            <>
+              {decks.length > 1 ? `${decks.length} decks · ` : ''}
+              {totalAll != null
+                ? `${loadedCount} of ${totalAll} cards loaded`
+                : 'Loading…'}
+            </>
+          )}
         </p>
+        {decks.length > 1 && (
+          <label className={styles.deckFilter}>
+            Deck:
+            <select
+              value={deckId ?? ''}
+              onChange={(event) => {
+                const raw = event.target.value;
+                setDeckId(raw === '' ? null : Number.parseInt(raw, 10));
+              }}
+            >
+              <option value="">All decks ({totalAll ?? '…'} cards)</option>
+              {decks.map((deck) => (
+                <option key={deck.id} value={deck.id}>
+                  {indent(Math.max(0, deck.path.length - 1))}
+                  {deck.path[deck.path.length - 1] ?? deck.fullName} (
+                  {deck.cardCount})
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
       </header>
 
       {stream.isLoading && cards.length === 0 ? (

--- a/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
+++ b/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
@@ -109,15 +109,15 @@ export default function PreviewApkgPage({
           ) : (
             <>
               {decks.length > 1 ? `${decks.length} decks · ` : ''}
-              {totalAll != null
-                ? `${loadedCount} of ${totalAll} cards loaded`
-                : 'Loading…'}
+              {totalAll == null
+                ? 'Loading…'
+                : `${loadedCount} of ${totalAll} cards loaded`}
             </>
           )}
         </p>
         {decks.length > 1 && (
           <label className={styles.deckFilter}>
-            Deck:
+            <span>Deck:</span>
             <select
               value={deckId ?? ''}
               onChange={(event) => {

--- a/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
+++ b/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ErrorPresenter } from '../../components/errors/ErrorPresenter';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+import { SkeletonList } from '../../components/Skeleton/Skeleton';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './PreviewApkgPage.module.css';
+import {
+  useApkgPreviewMeta,
+  useApkgPreviewStream,
+} from './useApkgPreviewStream';
+import { CardFrame } from './CardFrame';
+
+interface PreviewApkgPageProps {
+  setError: ErrorHandlerType;
+}
+
+export default function PreviewApkgPage({
+  setError,
+}: Readonly<PreviewApkgPageProps>) {
+  const { key } = useParams<{ key: string }>();
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const meta = useApkgPreviewMeta(key);
+  const stream = useApkgPreviewStream(key);
+
+  useEffect(() => {
+    const firstError = stream.error ?? meta.error;
+    if (firstError) setError(firstError);
+  }, [stream.error, meta.error, setError]);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    const node = sentinelRef.current;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (
+          entries[0]?.isIntersecting &&
+          stream.hasNextPage &&
+          !stream.isFetchingNextPage
+        ) {
+          stream.fetchNextPage();
+        }
+      },
+      { rootMargin: '400px 0px' }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [stream]);
+
+  const cards = useMemo(
+    () => stream.data?.pages.flatMap((page) => page.cards) ?? [],
+    [stream.data]
+  );
+
+  if (!key) {
+    return (
+      <div className={sharedStyles.page}>
+        <p className={styles.empty}>Missing upload id.</p>
+      </div>
+    );
+  }
+
+  const fatal = stream.error && !stream.data;
+  if (fatal) {
+    return (
+      <div className={sharedStyles.page}>
+        <header className={sharedStyles.pageHeader}>
+          <Link to="/downloads" className={styles.backLink}>
+            ← Back to downloads
+          </Link>
+          <h1 className={sharedStyles.title}>Preview</h1>
+        </header>
+        <ErrorPresenter
+          error={stream.error as Error}
+          onRetry={() => stream.refetch()}
+        />
+      </div>
+    );
+  }
+
+  const total = meta.data?.totalCards ?? stream.data?.pages[0]?.total;
+  const loadedCount = cards.length;
+
+  return (
+    <div className={sharedStyles.page}>
+      <header className={sharedStyles.pageHeader}>
+        <Link to="/downloads" className={styles.backLink}>
+          ← Back to downloads
+        </Link>
+        <h1 className={sharedStyles.title} data-hj-suppress>
+          Deck preview
+        </h1>
+        <p className={styles.summary}>
+          {meta.data?.deckNames.length
+            ? `${meta.data.deckNames.join(', ')} · `
+            : ''}
+          {total != null
+            ? `${loadedCount} of ${total} cards loaded`
+            : 'Loading…'}
+        </p>
+      </header>
+
+      {stream.isLoading && cards.length === 0 ? (
+        <SkeletonList count={4} />
+      ) : (
+        <div className={styles.cards}>
+          {cards.length === 0 && (
+            <p className={styles.empty}>This deck has no cards to preview.</p>
+          )}
+          {cards.map((card) => (
+            <CardFrame key={card.id} card={card} />
+          ))}
+        </div>
+      )}
+
+      <div
+        ref={sentinelRef}
+        className={styles.sentinel}
+        aria-hidden="true"
+      />
+
+      {stream.isFetchingNextPage && (
+        <div className={styles.loadingRow}>Loading more…</div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/PreviewApkgPage/index.tsx
+++ b/src/pages/PreviewApkgPage/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './PreviewApkgPage';

--- a/src/pages/PreviewApkgPage/useApkgPreviewStream.ts
+++ b/src/pages/PreviewApkgPage/useApkgPreviewStream.ts
@@ -1,0 +1,28 @@
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  ApkgPreviewBatch,
+  ApkgPreviewMeta,
+  getApkgPreviewBatch,
+  getApkgPreviewMeta,
+} from '../../lib/backend/getApkgPreview';
+
+export function useApkgPreviewMeta(key: string | undefined) {
+  return useQuery<ApkgPreviewMeta, Error>({
+    queryKey: ['apkgPreviewMeta', key],
+    enabled: !!key,
+    queryFn: () => getApkgPreviewMeta(key as string),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useApkgPreviewStream(key: string | undefined) {
+  return useInfiniteQuery<ApkgPreviewBatch, Error>({
+    queryKey: ['apkgPreview', key],
+    enabled: !!key,
+    initialPageParam: null,
+    queryFn: ({ pageParam }) =>
+      getApkgPreviewBatch(key as string, pageParam as number | null),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/pages/PreviewApkgPage/useApkgPreviewStream.ts
+++ b/src/pages/PreviewApkgPage/useApkgPreviewStream.ts
@@ -15,13 +15,18 @@ export function useApkgPreviewMeta(key: string | undefined) {
   });
 }
 
-export function useApkgPreviewStream(key: string | undefined) {
+export function useApkgPreviewStream(
+  key: string | undefined,
+  deckId: number | null = null
+) {
   return useInfiniteQuery<ApkgPreviewBatch, Error>({
-    queryKey: ['apkgPreview', key],
+    queryKey: ['apkgPreview', key, deckId],
     enabled: !!key,
     initialPageParam: null,
     queryFn: ({ pageParam }) =>
-      getApkgPreviewBatch(key as string, pageParam as number | null),
+      getApkgPreviewBatch(key as string, pageParam as number | null, {
+        deckId,
+      }),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     staleTime: 5 * 60 * 1000,
   });


### PR DESCRIPTION
## Summary
Client side of the .apkg preview feature. Pair with [2anki/server#1987](https://github.com/2anki/server/pull/1987).

- New lazy route \`/preview/apkg/:key\` gated by \`RequireAuth\`.
- \`useApkgPreviewStream\` / \`useApkgPreviewMeta\` hooks use \`useInfiniteQuery\` on the new server endpoints with the same IntersectionObserver-sentinel pattern as the Notion preview.
- Each card renders in its own \`<iframe sandbox=\"allow-same-origin\">\` with a \`srcDoc\` combining the note type's CSS and the server-rendered (already-sanitised) front/back HTML. Flip toggle per card.
- On \`/downloads\`, every row whose upload key ends in \`.apkg\` gets a **Preview** pill next to **Download**. Job downloads stay download-only for now.

## Out of scope (follow-up slices)
Cloze rendering, media rewriting, MathJax, \`.anki21b\` (zstd) — all called out in the server PR.

## Test plan
- [ ] Convert a Notion page → land on \`/downloads\` → click Preview on the fresh .apkg → iframe renders first batch, scroll paginates.
- [ ] Click \"Show back\" on a card — iframe updates, aria-pressed flips.
- [ ] Load a deck larger than 20 cards — second batch loads at the sentinel.
- [ ] Hit \`/preview/apkg/:key\` with an unknown key → ErrorPresenter with Retry.
- [ ] Non-.apkg upload row (e.g. .md) — no Preview pill shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)