### PR TITLE
ci(dependabot): group weekly minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,32 @@
 version: 2
 updates:
+  # npm — grouped so a single PR covers all weekly minor/patch bumps.
+  # Major bumps stay un-grouped (one PR each) so breaking changes get
+  # individual review.
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      development-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  # GitHub Actions — one PR per week for all workflow updates.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Matches [2anki/server#2002](https://github.com/2anki/server/pull/2002). Collapses the weekly Dependabot flood into:

- **production-dependencies** — minor/patch runtime deps
- **development-dependencies** — minor/patch dev deps
- **github-actions** — workflow updates

Major bumps stay as individual PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)