### PR TITLE
feat(pricing): prefill email on Stripe payment link for logged-in users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,7 +133,7 @@ function AppContent({
           />
           <Route
             path="/pricing"
-            element={<PricingPage isLoggedIn={isLoggedInResolved} />}
+            element={<PricingPage isLoggedIn={isLoggedInResolved} email={data?.user?.email} />}
           />
           <Route
             path="/"

--- a/src/pages/PricingPage/PricingPage.tsx
+++ b/src/pages/PricingPage/PricingPage.tsx
@@ -6,13 +6,15 @@ import styles from './PricingPage.module.css';
 
 interface PricingPageProps {
   isLoggedIn: boolean;
+  email?: string;
 }
 
 export default function PricingPage({
   isLoggedIn,
+  email,
 }: Readonly<PricingPageProps>) {
   const subcribeLink = isLoggedIn
-    ? getSubscribeLink()
+    ? getSubscribeLink(email)
     : '/login?redirect=/pricing';
   const lifetimeLink = getLifetimeLink();
 

--- a/src/pages/PricingPage/payment.links.ts
+++ b/src/pages/PricingPage/payment.links.ts
@@ -1,7 +1,10 @@
-export const getSubscribeLink = () =>
-  process.env.NODE_ENV === 'development'
-    ? 'https://buy.stripe.com/test_fZebM83k00Rj6PeeUU'
-    : 'https://buy.stripe.com/cN2cPC6ek7RCbjGdQU';
+export const getSubscribeLink = (email?: string) => {
+  const base =
+    process.env.NODE_ENV === 'development'
+      ? 'https://buy.stripe.com/test_fZebM83k00Rj6PeeUU'
+      : 'https://buy.stripe.com/cN2cPC6ek7RCbjGdQU';
+  return email ? `${base}?prefilled_email=${encodeURIComponent(email)}` : base;
+};
 
 export const getLifetimeLink = () =>
   'mailto:support@2anki.net?subject=Lifetime%20Access%20for%202anki.net&body=Hello,%20I%20would%20like%20to%20purchase%20a%20lifetime%20access%20for%202anki.net.';


### PR DESCRIPTION
## Summary

- `getSubscribeLink(email?)` now appends `?prefilled_email=<encoded>` when an email is provided
- `PricingPage` accepts an optional `email` prop and passes it through
- `App.tsx` passes `data?.user?.email` (from the existing `useUserLocals` call) to `<PricingPage>`

## Test plan

- [x] Log in and visit `/pricing` — confirm the Subscribe link includes `?prefilled_email=your@email.com`
- [x] Visit `/pricing` while logged out — confirm the link redirects to `/login?redirect=/pricing` (unchanged)
- [x] Click Subscribe while logged in — confirm Stripe checkout has email prefilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)