### PR TITLE
fix(subscription): use cancel_at instead of current_period_end

### DIFF
--- a/src/lib/backend/getSubscriptionStatus.ts
+++ b/src/lib/backend/getSubscriptionStatus.ts
@@ -10,7 +10,7 @@ export interface StripeSubscriptionSummary {
   id: string;
   status: string;
   cancel_at_period_end: boolean;
-  current_period_end: number | null;
+  cancel_at: number | null;
   canceled_at: number | null;
   plan: StripePlanSummary | null;
 }

--- a/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -104,7 +104,7 @@ export function SubscriptionManagement({
           {view.kind === 'active' && (
             <div className={styles.activeBadge}>
               Active — renews on{' '}
-              <strong>{formatDate(view.subscription.current_period_end)}</strong>
+              <strong>{formatDate(view.subscription.cancel_at)}</strong>
               .
               {formatPlan(view.subscription) && (
                 <p className={styles.planDetail}>
@@ -117,7 +117,7 @@ export function SubscriptionManagement({
           {view.kind === 'scheduled' && (
             <div className={styles.scheduledBadge}>
               Scheduled to cancel on{' '}
-              <strong>{formatDate(view.subscription.current_period_end)}</strong>
+              <strong>{formatDate(view.subscription.cancel_at)}</strong>
               . You will keep access until then.
               {formatPlan(view.subscription) && (
                 <p className={styles.planDetail}>


### PR DESCRIPTION
## Summary

- The server was upgraded to Stripe v22 which removed `current_period_end` from the Subscription object; it now returns `cancel_at` instead
- Update `StripeSubscriptionSummary` type and both display sites in `SubscriptionManagement` to read `cancel_at`
- Fixes "Scheduled to cancel on an unknown date" shown to users with a scheduled cancellation

## Test plan

- [ ] Log in as a user with a subscription scheduled for cancellation — the cancel date should render correctly instead of "an unknown date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)