### PR TITLE
feat: show warning when markdown heuristic detection was used

### DIFF
--- a/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -82,6 +82,7 @@ function UploadForm({
   const [downloadLink, setDownloadLink] = useState<null | string>('');
   const [deckName, setDeckName] = useState('');
   const [cardCount, setCardCount] = useState<number | null>(null);
+  const [warningMessage, setWarningMessage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const convertRef = useRef<HTMLButtonElement>(null);
 
@@ -119,6 +120,7 @@ function UploadForm({
         setDownloadLink(null);
         return setErrorMessage(new Error(message));
       }
+      setWarningMessage(request.headers.get('X-Warning'));
       setDeckName(resolveDeckName(request.headers));
       setCardCount(parseCardCountHeader(request.headers));
       const blob = await request.blob();
@@ -170,6 +172,9 @@ function UploadForm({
         uploading={uploading}
         cardCount={cardCount}
       />
+      {warningMessage && (
+        <p className={styles.notificationWarning}>{warningMessage}</p>
+      )}
       <button
         aria-label="Upload file"
         className={styles.hidden}


### PR DESCRIPTION
## Summary

- Reads `X-Warning` from the upload response headers on a successful (200) upload
- Displays it in a `notificationWarning` box below the download button

## Context

Companion to server PR [2anki/server#2018](https://github.com/2anki/server/pull/2018) which adds heuristic Markdown card detection. When the server falls back to guessing the Markdown structure it sets an `X-Warning` header — this PR surfaces that to the user so they know the result may vary and can adjust their settings.

## Test plan

- [ ] Upload a Notion Markdown export — warning box should appear below the download button after conversion
- [ ] Upload a standard Notion HTML export — no warning box shown
- [ ] Warning box uses existing `notificationWarning` styles (amber/yellow)

> **Depends on:** [2anki/server#2018](https://github.com/2anki/server/pull/2018) — merge server PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)