### PR TITLE
fix: subscription management display and email linking bugs

### DIFF
--- a/src/lib/backend/getSubscriptionStatus.ts
+++ b/src/lib/backend/getSubscriptionStatus.ts
@@ -12,6 +12,7 @@ export interface StripeSubscriptionSummary {
   cancel_at_period_end: boolean;
   cancel_at: number | null;
   canceled_at: number | null;
+  current_period_end: number | null;
   plan: StripePlanSummary | null;
 }
 

--- a/src/pages/AccountPage/AccountPage.module.css
+++ b/src/pages/AccountPage/AccountPage.module.css
@@ -227,6 +227,16 @@
   margin-bottom: 0.75rem;
 }
 
+.infoBadge {
+  padding: 0.75rem 1rem;
+  background: var(--color-info-light, #eff6ff);
+  border: 1px solid var(--color-info-border, #bfdbfe);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: var(--color-info-text, #1e40af);
+  margin-bottom: 0.75rem;
+}
+
 .cancelledBadge {
   padding: 0.75rem 1rem;
   background: var(--color-bg-secondary, #f3f4f6);

--- a/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -92,7 +92,9 @@ export function SubscriptionManagement({
     performLinkEmail(linkEmail);
   };
 
-  const isEmailLinked = locals?.subscriptionInfo?.linked_email === user.email;
+  const isEmailLinked =
+    locals?.subscriptionInfo?.linked_email === user.email ||
+    locals?.subscriptionInfo?.email === user.email;
 
   if (!hasActivePlan && !user) {
     return null;
@@ -116,7 +118,7 @@ export function SubscriptionManagement({
           {view.kind === 'active' && (
             <div className={styles.activeBadge}>
               Active — renews on{' '}
-              <strong>{formatDate(view.subscription.cancel_at)}</strong>
+              <strong>{formatDate(view.subscription.current_period_end)}</strong>
               .
               {formatPlan(view.subscription) && (
                 <p className={styles.planDetail}>
@@ -152,7 +154,7 @@ export function SubscriptionManagement({
             </div>
           )}
 
-          {view.kind === 'none' && stripeStatus.isLoading && (
+          {stripeStatus.isLoading && view.kind === 'none' && (
             <p className={sharedStyles.smallDescription}>
               Loading subscription status…
             </p>
@@ -161,7 +163,7 @@ export function SubscriptionManagement({
           {view.kind === 'active' &&
             view.subscription.plan?.amount != null &&
             view.subscription.plan.amount < 600 && (
-              <div className={styles.scheduledBadge}>
+              <div className={styles.infoBadge}>
                 You're on our legacy $2/mo plan. If you cancel, this rate won't
                 be available again — the current price is $6/mo.
               </div>


### PR DESCRIPTION
## Summary

Four bugs fixed in the account page subscription management section:

1. **"Active — renews on unknown date"** — component was reading `cancel_at` (always null for non-cancelling subs) instead of `current_period_end`. Added field to the TypeScript interface and used it in the badge.

2. **isEmailLinked false for direct-match users** — the check only compared `linked_email === user.email`, missing users whose Stripe email is the same as their 2anki email. They'd see the "link your subscription email" form unnecessarily. Fixed by also checking `subscriptionInfo.email === user.email`.

3. **Legacy $2/mo notice using wrong badge style** — was `scheduledBadge` (warning yellow), changed to `infoBadge` (info blue) since it's informational, not a warning.

4. **New `infoBadge` CSS class** — added to `AccountPage.module.css` with `--color-info-*` design tokens.

Depends on server PR #2022 (adds `current_period_end` to the response).

## Test plan

- [ ] Log in as a subscriber — confirm banner shows real renewal date
- [ ] Log in as user whose 2anki email = Stripe email — confirm email linking form is NOT shown
- [ ] Log in as legacy $2/mo subscriber — confirm informational blue badge appears (not yellow)
- [ ] `pnpm typecheck` and `pnpm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)