### PR TITLE
docs: announce move to 2anki/server monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **This repository has moved.** Development now happens in the [`2anki/server`](https://github.com/2anki/server) monorepo under the [`web/`](https://github.com/2anki/server/tree/main/web) folder. Please open new issues and pull requests there.
+
 Frontend code for [2anki.net](https://2anki.net), for backend see https://github.com/2anki/server
 
 <p align="center"><img width="256" src="public/mascot/Notion%201.png?raw=true" alt="Notion to Anki logo" /></p>


### PR DESCRIPTION
## Summary
- Adds a notice at the top of the README marking this repo as moved to the [`2anki/server`](https://github.com/2anki/server) monorepo under the `web/` folder
- Directs new issues and PRs to the monorepo

## Test plan
- [ ] Render README on GitHub and confirm the `> [!IMPORTANT]` callout displays correctly
- [ ] Confirm links to `2anki/server` and `web/` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)